### PR TITLE
feat: refill wallets on rolling basis

### DIFF
--- a/packages/cli/src/handler.ts
+++ b/packages/cli/src/handler.ts
@@ -103,6 +103,15 @@ export const bundlerHandler = async (args: IBundlerArgsInput): Promise<void> => 
         parsedArgs.utilityPrivateKey
     )
 
+    setInterval(async () => {
+        await senderManager.validateAndRefillWallets(
+            client,
+            walletClient,
+            parsedArgs.minBalance,
+            parsedArgs.utilityPrivateKey
+        )
+    }, parsedArgs.refillInterval);
+
     const monitor = new Monitor()
 
     const executor = new BasicExecutor(

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -32,6 +32,12 @@ export const bundlerOptions: CliCommandOptions<IBundlerArgsInput> = {
         type: "string",
         require: true
     },
+    refillInterval: {
+        description: "Interval to refill the signer balance (in ms)",
+        type: "number",
+        require: true,
+        default: 1000 * 60 * 5
+    },
     rpcUrl: {
         description: "RPC url to connect to",
         type: "string",

--- a/packages/config/src/bundler.ts
+++ b/packages/config/src/bundler.ts
@@ -17,7 +17,9 @@ export const bundlerArgsSchema = z.object({
     utilityPrivateKey: hexData32Schema.transform((val) => privateKeyToAccount(val) satisfies Account),
     maxSigners: z.number().int().min(0).optional(),
     rpcUrl: z.string().url(),
+    
     minBalance: z.string().transform((val) => BigInt(val)),
+    refillInterval: z.number().int().min(0),
 
     minStake: z.number().int().min(0),
     minUnstakeDelay: z.number().int().min(0),


### PR DESCRIPTION
Changes
- Added `refillInterval` arguments for CLI with a default of 5 minutes
- `validateAndRefillWallets` is called every `refillInterval` to refill wallets