### PR TITLE
fix: block range too large

### DIFF
--- a/packages/api/src/rpcHandler.ts
+++ b/packages/api/src/rpcHandler.ts
@@ -202,21 +202,22 @@ export class RpcHandler implements IRpcEndpoint {
     async eth_getUserOperationByHash(userOperationHash: HexData32): Promise<GetUserOperationByHashResponseResult> {
         const userOperationEventAbiItem = getAbiItem({ abi: EntryPointAbi, name: "UserOperationEvent" })
 
+        // Only query up to the last `fullBlockRange` = 20000 blocks
+        const latestBlock = await this.config.publicClient.getBlockNumber()
+        const fullBlockRange = 20000n
 
         let fromBlock: bigint
         if (this.config.usingTenderly) {
-            const latestBlock = await this.config.publicClient.getBlockNumber()
             fromBlock = latestBlock - 100n
         } else {
-            fromBlock = 0n
+            fromBlock = latestBlock - fullBlockRange
         }
         
-
         const filterResult = await this.config.publicClient.getLogs({
             address: this.config.entryPoint,
             event: userOperationEventAbiItem,
             fromBlock,
-            toBlock: "latest",
+            toBlock: latestBlock,
             args: {
                 userOpHash: userOperationHash
             }
@@ -275,19 +276,22 @@ export class RpcHandler implements IRpcEndpoint {
     async eth_getUserOperationReceipt(userOperationHash: HexData32): Promise<GetUserOperationReceiptResponseResult> {
         const userOperationEventAbiItem = getAbiItem({ abi: EntryPointAbi, name: "UserOperationEvent" })
 
+        // Only query up to the last `fullBlockRange` = 20000 blocks
+        const latestBlock = await this.config.publicClient.getBlockNumber()
+        const fullBlockRange = 20000n
+
         let fromBlock: bigint
         if (this.config.usingTenderly) {
-            const latestBlock = await this.config.publicClient.getBlockNumber()
             fromBlock = latestBlock - 100n
         } else {
-            fromBlock = 0n
+            fromBlock = latestBlock - fullBlockRange
         }
 
         const filterResult = await this.config.publicClient.getLogs({
             address: this.config.entryPoint,
             event: userOperationEventAbiItem,
             fromBlock,
-            toBlock: "latest",
+            toBlock: latestBlock,
             args: {
                 userOpHash: userOperationHash
             }


### PR DESCRIPTION
Limit querying for user operation hash (eth_getUserOperationReceipt, eth_getUserOperationByHash) to the last 20000 blocks