### PR TITLE
add ability to setup log level for each module individually

### DIFF
--- a/packages/cli/src/config/bundler.ts
+++ b/packages/cli/src/config/bundler.ts
@@ -3,6 +3,8 @@ import { Hex } from "viem"
 import { Account, privateKeyToAccount } from "viem/accounts"
 import { z } from "zod"
 
+const logLevel = z.enum(["trace", "debug", "info", "warn", "error", "fatal"])
+
 export const bundlerArgsSchema = z.object({
     // allow both a comma separated list of addresses
     // (better for cli and env vars) or an array of addresses
@@ -78,7 +80,14 @@ export const bundlerArgsSchema = z.object({
 
     environment: z.enum(["production", "staging", "development"]),
 
-    logLevel: z.enum(["trace", "debug", "info", "warn", "error", "fatal"]),
+    logLevel: logLevel,
+    publicClientLogLevel: logLevel.optional(),
+    walletClientLogLevel: logLevel.optional(),
+    rpcLogLevel: logLevel.optional(),
+    mempoolLogLevel: logLevel.optional(),
+    executorLogLevel: logLevel.optional(),
+    reputationManagerLogLevel: logLevel.optional(),
+    nonceQueuerLogLevel: logLevel.optional(),
     logEnvironment: z.enum(["production", "development"]),
 
     bundleMode: z.enum(["auto", "manual"]),

--- a/packages/cli/src/config/options.ts
+++ b/packages/cli/src/config/options.ts
@@ -106,10 +106,45 @@ export const bundlerOptions: CliCommandOptions<IBundlerArgsInput> = {
         default: 1000
     },
     logLevel: {
-        description: "Log level",
+        description: "Default log level",
         type: "string",
         require: true,
         default: "debug"
+    },
+    publicClientLogLevel: {
+        description: "Log level for the publicClient module",
+        type: "string",
+        require: false,
+    },
+    walletClientLogLevel: {
+        description: "Log level for the walletClient module",
+        type: "string",
+        require: false,
+    },
+    rpcLogLevel: {
+        description: "Log level for the rpc module",
+        type: "string",
+        require: false,
+    },
+    mempoolLogLevel: {
+        description: "Log level for the mempool module",
+        type: "string",
+        require: false,
+    },
+    executorLogLevel: {
+        description: "Log level for the executor module",
+        type: "string",
+        require: false,
+    },
+    reputationManagerLogLevel: {
+        description: "Log level for the executor module",
+        type: "string",
+        require: false,
+    },
+    nonceQueuerLogLevel: {
+        description: "Log level for the executor module",
+        type: "string",
+        require: false,
     },
     environment: {
         description: "Environment",

--- a/packages/cli/src/customTransport.ts
+++ b/packages/cli/src/customTransport.ts
@@ -47,7 +47,7 @@ export function customTransport(
 
                     const [{ error, result }] = await fn(body)
                     if (error) {
-                        logger.debug(
+                        logger.error(
                             {
                                 error,
                                 body
@@ -60,7 +60,7 @@ export function customTransport(
                             url: url
                         })
                     }
-                    logger.debug({ body, result }, "Received response")
+                    logger.info({ body, result }, "Received response")
                     return result
                 },
                 retryCount,


### PR DESCRIPTION
this feature will allow us to tune logging setting more flexibly. for example, we may want to have default log level as `debug`, but for RPC queries we want to log only errors.