### PR TITLE
improve metric about received ops count

### DIFF
--- a/packages/rpc/src/rpcHandler.ts
+++ b/packages/rpc/src/rpcHandler.ts
@@ -371,10 +371,10 @@ export class RpcHandler implements IRpcEndpoint {
                     .baseFeePerGas
                 gasPrice =
                     userOperation.maxFeePerGas <
-                    (blockBaseFee ?? 0n) + userOperation.maxPriorityFeePerGas
+                        (blockBaseFee ?? 0n) + userOperation.maxPriorityFeePerGas
                         ? userOperation.maxFeePerGas
                         : userOperation.maxPriorityFeePerGas +
-                          (blockBaseFee ?? 0n)
+                        (blockBaseFee ?? 0n)
             }
             const calculatedCallGasLimit =
                 executionResult.paid / gasPrice -
@@ -435,14 +435,27 @@ export class RpcHandler implements IRpcEndpoint {
         userOperation: UserOperation,
         entryPoint: Address
     ): Promise<SendUserOperationResponseResult> {
-        await this.addToMempoolIfValid(userOperation, entryPoint)
+        let status;
+        try {
+            status = await this.addToMempoolIfValid(userOperation, entryPoint)
 
-        const hash = getUserOperationHash(
-            userOperation,
-            entryPoint,
-            this.chainId
-        )
-        return hash
+            const hash = getUserOperationHash(
+                userOperation,
+                entryPoint,
+                this.chainId
+            )
+            return hash
+        } catch (error) {
+            status = "rejected"
+            throw error;
+        } finally {
+            this.metrics.userOperationsReceived
+                .labels({
+                    status,
+                    type: "default"
+                })
+                .inc()
+        }
     }
 
     async eth_getUserOperationByHash(
@@ -815,7 +828,7 @@ export class RpcHandler implements IRpcEndpoint {
     }
 
     // check if we want to bundle userOperation. If yes, add to mempool
-    async addToMempoolIfValid(op: MempoolUserOperation, entryPoint: Address) {
+    async addToMempoolIfValid(op: MempoolUserOperation, entryPoint: Address): Promise<'added' | 'queued'> {
         const userOperation = deriveUserOperation(op)
         if (this.entryPoint !== entryPoint) {
             throw new RpcError(
@@ -864,7 +877,6 @@ export class RpcHandler implements IRpcEndpoint {
         }
 
         this.logger.trace({ userOperation, entryPoint }, "beginning validation")
-        this.metrics.userOperationsReceived.inc()
 
         if (
             userOperation.preVerificationGas === 0n ||
@@ -936,10 +948,12 @@ export class RpcHandler implements IRpcEndpoint {
                         ValidationErrors.SimulateValidation
                     )
                 }
+                return 'added'
             }
-        } else {
-            this.nonceQueuer.add(userOperation)
         }
+
+        this.nonceQueuer.add(userOperation)
+        return 'queued'
     }
 
     async pimlico_sendCompressedUserOperation(
@@ -947,21 +961,34 @@ export class RpcHandler implements IRpcEndpoint {
         inflatorAddress: Address,
         entryPoint: Address
     ) {
-        var { inflatedOp, inflatorId } = await this.validateAndInflateCompressedUserOperation(inflatorAddress, compressedCalldata)
+        let status;
+        try {
+            var { inflatedOp, inflatorId } = await this.validateAndInflateCompressedUserOperation(inflatorAddress, compressedCalldata)
 
-        const compressedUserOp: CompressedUserOperation = {
-            compressedCalldata,
-            inflatedOp,
-            inflatorAddress,
-            inflatorId
+            const compressedUserOp: CompressedUserOperation = {
+                compressedCalldata,
+                inflatedOp,
+                inflatorAddress,
+                inflatorId
+            }
+
+            // check userOps inputs.
+            status = await this.addToMempoolIfValid(compressedUserOp, entryPoint)
+
+            const hash = getUserOperationHash(inflatedOp, entryPoint, this.chainId)
+
+            return hash
+        } catch (error) {
+            status = "rejected"
+            throw error;
+        } finally {
+            this.metrics.userOperationsReceived
+                .labels({
+                    status,
+                    type: "compressed"
+                })
+                .inc()
         }
-
-        // check userOps inputs.
-        await this.addToMempoolIfValid(compressedUserOp, entryPoint)
-
-        const hash = getUserOperationHash(inflatedOp, entryPoint, this.chainId)
-
-        return hash
     }
 
     private async validateAndInflateCompressedUserOperation(inflatorAddress: Address, compressedCalldata: Hex): Promise<{ inflatedOp: UserOperation; inflatorId: number }> {

--- a/packages/rpc/src/rpcHandler.ts
+++ b/packages/rpc/src/rpcHandler.ts
@@ -452,7 +452,7 @@ export class RpcHandler implements IRpcEndpoint {
             this.metrics.userOperationsReceived
                 .labels({
                     status,
-                    type: "default"
+                    type: "regular"
                 })
                 .inc()
         }

--- a/packages/utils/src/metrics.ts
+++ b/packages/utils/src/metrics.ts
@@ -54,70 +54,70 @@ export function createMetrics(registry: Registry, register = true) {
     const walletsAvailable = new Gauge({
         name: "alto_executor_wallets_available_count",
         help: "Number of available executor wallets used to bundle",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers
     })
 
     const walletsTotal = new Gauge({
         name: "alto_executor_wallets_total_count",
         help: "Number of total executor wallets used to bundle",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers
     })
 
     const userOperationsIncluded = new Counter({
         name: "alto_user_operations_included_count",
         help: "Number of user operations bundles included on-chain",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers
     })
 
     const userOperationsSubmitted = new Counter({
         name: "alto_user_operations_submitted_count",
         help: "Number of user operations bundles submitted on-chain",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers
     })
 
     const bundlesIncluded = new Counter({
         name: "alto_bundles_included_count",
         help: "Number of user operations bundles included on-chain",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers
     })
 
     const bundlesSubmitted = new Counter({
         name: "alto_bundles_submitted_count",
         help: "Number of user operations bundles submitted on-chain",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers
     })
 
     const userOperationsReceived = new Counter({
-        name: "alto_user_operations_received_count",
+        name: "alto_user_operations_received_total",
         help: "Number of user operations received",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: ["status"] as const,
         registers
     })
 
     const userOperationsValidationSuccess = new Counter({
         name: "alto_user_operations_validation_success_count",
         help: "Number of user operations successfully validated",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers
     })
 
     const userOperationsValidationFailure = new Counter({
         name: "alto_user_operations_validation_failure_count",
         help: "Number of user operations failed to validate",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers
     })
 
     const userOperationInclusionDuration = new Histogram({
         name: "alto_user_operation_inclusion_duration_seconds",
         help: "Duration of user operation inclusion from first submission to inclusion on-chain",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers,
         buckets: [
             0.5, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 25, 30, 40, 50, 60, 120,
@@ -128,7 +128,7 @@ export function createMetrics(registry: Registry, register = true) {
     const verificationGasLimitEstimationTime = new Histogram({
         name: "alto_verification_gas_limit_estimation_time_seconds",
         help: "Total duration of verification gas limit estimation",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers,
         buckets: [0.1, 0.2, 0.3, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5]
     })
@@ -136,7 +136,7 @@ export function createMetrics(registry: Registry, register = true) {
     const verificationGasLimitEstimationCount = new Histogram({
         name: "alto_verification_gas_limit_estimation_count",
         help: "Number of verification gas limit estimation calls",
-        labelNames: ["network", "chainId"] as const,
+        labelNames: [] as const,
         registers,
         buckets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     })

--- a/packages/utils/src/metrics.ts
+++ b/packages/utils/src/metrics.ts
@@ -96,7 +96,7 @@ export function createMetrics(registry: Registry, register = true) {
     const userOperationsReceived = new Counter({
         name: "alto_user_operations_received_total",
         help: "Number of user operations received",
-        labelNames: ["status"] as const,
+        labelNames: ["status", "type"] as const,
         registers
     })
 


### PR DESCRIPTION
## alto_user_operations_received_total

description: Number of user operations received

type: counter

labels:

- status — handling status: `added`, `rejected` or `queued`
- type — `regular` or `compressed`