### PR TITLE
feat: add bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "alto": "./src/lib/cli/alto.js"
     },
     "scripts": {
+        "prepare": "pnpm run build",
         "clean": "rm -rf ./src/lib ./src/*.tsbuildinfo",
         "clean-modules": "rm -rf ./src/node_modules node_modules",
         "build": "pnpm -r run build",


### PR DESCRIPTION
To be able to run `pnpm alto run` instead of `node ./node_modules/alto/src/lib/cli/alto.js run`