### PR TITLE
remove unnecessary if statement and variable assignment in `calcVerificationGasAndCallGasLimit`

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -353,17 +353,9 @@ export function calcVerificationGasAndCallGasLimit(
         ((executionResult.preOpGas - userOperation.preVerificationGas) * 3n) /
         2n
 
-    let gasPrice: bigint
-
-    if (userOperation.maxPriorityFeePerGas === userOperation.maxFeePerGas) {
-        gasPrice = userOperation.maxFeePerGas
-    } else {
-        gasPrice = userOperation.maxFeePerGas
-    }
-
     const calculatedCallGasLimit =
         callDataResult?.gasUsed ??
-        executionResult.paid / gasPrice - executionResult.preOpGas
+        executionResult.paid / userOperation.maxFeePerGas - executionResult.preOpGas
 
     let callGasLimit =
         (calculatedCallGasLimit > 9000n ? calculatedCallGasLimit : 9000n) +


### PR DESCRIPTION
This PR:
- Remove unnecessary if statement in calcVerificationGasAndCallGasLimit
- I couldn't run the tests by following the instructions in the readme, so YOLO 
```
> @pimlico/alto@0.0.4 test /Users/mmv/projects/safe/alto/src
> test -d test && mocha test/**/*.test.ts --exit || echo 'No test folder found. Skipping tests.' "true"

No test folder found. Skipping tests. true
```