### PR TITLE
remove `pino-pretty` for compatibility with `pkg`

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -61,12 +61,6 @@ export const customSerializer: SerializerFn = (input: AnyObject): AnyObject => {
 
 export const initDebugLogger = (level = "debug"): Logger => {
     const l = logger({
-        transport: {
-            target: "pino-pretty",
-            options: {
-                colorize: true
-            }
-        },
         formatters: {
             level: logLevel,
             log: customSerializer


### PR DESCRIPTION
To solve a compatibility issue with `pkg`, see https://github.com/vercel/pkg/issues/1419#issuecomment-1102489661. It's still possible to get the pino-pretty effect by running via `./alto | pnpm pino-pretty`.

Note: feel free to close, not sure if this should make it into `main`, just wanted to put it here for reference if someone else runs into the same issue.