### PR TITLE
build: update checkout action to v4

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/on-push-to-main.yaml
+++ b/.github/workflows/on-push-to-main.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install core dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/prune-tags.yaml
+++ b/.github/workflows/prune-tags.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:

--- a/contracts/.github/workflows/test.yml
+++ b/contracts/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
Bumps checkout to v4 for future-proofing against Node 20 runner updates. Workflows compile the same.