### PR TITLE
fix: empty `$forkMode` handling

### DIFF
--- a/scripts/run-local-instance.sh
+++ b/scripts/run-local-instance.sh
@@ -117,7 +117,7 @@ if [ -n "$localMode" ] && [ -z "$forkMode" ]; then
     fi
 fi
 
-if [ -n $forkMode ] && [ -z "$localMode" ]; then
+if [ -n "$forkMode" ] && [ -z "$localMode" ]; then
     forkTimestamp=$(cast block $blockNum --rpc-url $rpcUrl | grep time | awk '{print $2}' | tr -d '\n')
 
     # build alto intance.


### PR DESCRIPTION
if `$forkMode` is empty and not quoted, Bash throws an error on `[ -n ]`.  

fixed it by quoting the variable properly.