### PR TITLE
Fix package to include missing contract jsons

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -14,9 +14,11 @@
         "esm/**/*.d.ts",
         "esm/**/*.js",
         "esm/**/*.js.map",
+        "esm/**/*.json",
         "lib/**/*.d.ts",
         "lib/**/*.js",
         "lib/**/*.js.map",
+        "lib/**/*.json",
         "contracts/**/*",
         "*.d.ts",
         "*.js"


### PR DESCRIPTION
The npm package is missing a couple json files that are essential for execution.

```
src/esm/contracts/PimlicoEntryPointSimulationsV7.sol/PimlicoEntryPointSimulationsV7.json
src/esm/contracts/PimlicoEntryPointSimulationsV8.sol/PimlicoEntryPointSimulationsV8.json
src/lib/contracts/PimlicoEntryPointSimulationsV7.sol/PimlicoEntryPointSimulationsV7.json
src/lib/contracts/PimlicoEntryPointSimulationsV8.sol/PimlicoEntryPointSimulationsV8.json
```
