### PR TITLE
refresh bundle once more if bundler fails to replace transaction

### DIFF
--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -12,6 +12,7 @@ import type { AltoConfig } from "../createConfig"
 import { SenderManager } from "./senderManager"
 import { GasPriceParameters } from "@alto/types"
 import { UserOpMonitor } from "./userOpMonitor"
+import { getUserOpHashes } from "./utils"
 
 const SCALE_FACTOR = 10 // Interval increases by 10ms per task per minute
 const RPM_WINDOW = 60000 // 1 minute window in ms
@@ -363,7 +364,11 @@ export class ExecutorManager {
                 await this.senderManager.markWalletProcessed(executor)
 
                 this.logger.warn(
-                    { oldTxHash, reason },
+                    {
+                        oldTxHash,
+                        reason,
+                        userOps: getUserOpHashes(submittedBundle.bundle.userOps)
+                    },
                     "failed to replace transaction"
                 )
 

--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -354,14 +354,13 @@ export class ExecutorManager {
             const isPending =
                 await this.userOpMonitor.refreshBundleStatus(submittedBundle)
 
-            // if isPending then this bundle never made it onchain so we need to cleanup.
+            // if isPending then this bundle never made it onchain.
             if (isPending) {
+                const { rejectedUserOps, recoverableOps, reason } = bundleResult
+
                 // Free wallet as no bundle was sent.
                 await this.userOpMonitor.stopTrackingBundle(submittedBundle)
                 await this.senderManager.markWalletProcessed(executor)
-
-                // If no transaction ever landed onchain, we should drop userOps
-                const { rejectedUserOps, recoverableOps, reason } = bundleResult
 
                 this.logger.warn(
                     { oldTxHash, reason },

--- a/src/mempool/mempool.ts
+++ b/src/mempool/mempool.ts
@@ -135,6 +135,7 @@ export class Mempool {
                     entryPoint
                 )
 
+                // Reject userOp if resubmission failed.
                 if (!success) {
                     this.logger.error(
                         { userOpHash, failureReason },


### PR DESCRIPTION
Refresh bundle status once more if we fail to replace the transaction. This ensures correct metrics are logged as currently the following cases are not accounted for
- bundle is frontran
- bundle is included but replacement transaction failed to send