### PR TITLE
log correct inclusion timestamp

### DIFF
--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -267,6 +267,7 @@ export class ExecutorManager {
             return
         }
         this.currentlyHandlingBlock = true
+        const blockReceivedTimestamp = Date.now()
 
         const pendingBundles = this.userOpMonitor.getPendingBundles()
 
@@ -290,7 +291,8 @@ export class ExecutorManager {
                 if (receipt.status === "included") {
                     await this.userOpMonitor.processIncludedBundle({
                         submittedBundle: pendingBundles[index],
-                        bundleReceipt: receipt
+                        bundleReceipt: receipt,
+                        blockReceivedTimestamp
                     })
                 }
 

--- a/src/executor/userOpMonitor.ts
+++ b/src/executor/userOpMonitor.ts
@@ -97,10 +97,12 @@ export class UserOpMonitor {
 
     async processIncludedBundle({
         submittedBundle,
-        bundleReceipt
+        bundleReceipt,
+        blockReceivedTimestamp
     }: {
         submittedBundle: SubmittedBundleInfo
         bundleReceipt: BundleStatus<"included">
+        blockReceivedTimestamp: number
     }) {
         const { bundle } = submittedBundle
         const { userOps, entryPoint } = bundle
@@ -131,7 +133,8 @@ export class UserOpMonitor {
                     userOpReceipt,
                     transactionHash,
                     blockNumber,
-                    entryPoint
+                    entryPoint,
+                    blockReceivedTimestamp
                 )
             }
         })()
@@ -283,7 +286,8 @@ export class UserOpMonitor {
         userOpReceipt: any,
         transactionHash: Hash,
         blockNumber: bigint,
-        entryPoint: Address
+        entryPoint: Address,
+        blockReceivedTimestamp: number
     ) {
         const { userOpHash, userOp, submissionAttempts, addedToMempool } =
             userOpInfo
@@ -314,7 +318,7 @@ export class UserOpMonitor {
 
         // Track metrics
         this.metrics.userOpInclusionDuration.observe(
-            (Date.now() - addedToMempool) / 1000
+            (blockReceivedTimestamp - addedToMempool) / 1000
         )
         this.metrics.userOpsSubmissionAttempts.observe(submissionAttempts)
 


### PR DESCRIPTION
- Use handleBlock timestamp instead of Date.now() when recording inclusion metrics 