### PR TITLE
refactor(rpc): replace epSimulationsAddress with entryPoint

### DIFF
--- a/src/rpc/estimation/gasEstimations07.ts
+++ b/src/rpc/estimation/gasEstimations07.ts
@@ -454,7 +454,7 @@ export class GasEstimator07 {
         const viemStateOverride = await prepareSimulationOverrides07({
             userOp,
             queuedUserOps,
-            epSimulationsAddress,
+            entryPoint,
             gasPriceManager: this.gasPriceManager,
             userStateOverrides: stateOverrides,
             config: this.config
@@ -505,15 +505,10 @@ export class GasEstimator07 {
         queuedUserOps: UserOperationV07[]
         userStateOverrides?: StateOverrides | undefined
     }): Promise<SimulateHandleOpResult> {
-        const { epSimulationsAddress } = this.getSimulationContracts(
-            entryPoint,
-            userOp
-        )
-
         const viemStateOverride = await prepareSimulationOverrides07({
             userOp,
             queuedUserOps,
-            epSimulationsAddress,
+            entryPoint,
             gasPriceManager: this.gasPriceManager,
             userStateOverrides: userStateOverrides,
             config: this.config

--- a/src/rpc/estimation/utils.ts
+++ b/src/rpc/estimation/utils.ts
@@ -296,14 +296,14 @@ export async function prepareSimulationOverrides06({
 export async function prepareSimulationOverrides07({
     userOp,
     queuedUserOps,
-    epSimulationsAddress,
+    entryPoint,
     gasPriceManager,
     userStateOverrides = {},
     config
 }: {
     userOp: UserOperationV07
     queuedUserOps: UserOperationV07[]
-    epSimulationsAddress: Address
+    entryPoint: Address
     gasPriceManager: GasPriceManager
     userStateOverrides?: StateOverrides
     config: Pick<AltoConfig, "codeOverrideSupport" | "balanceOverride">
@@ -317,8 +317,10 @@ export async function prepareSimulationOverrides07({
             const slot = keccak256(toHex("BLOCK_BASE_FEE_PER_GAS"))
             const value = toHex(baseFee, { size: 32 })
 
-            mergedStateOverrides[epSimulationsAddress] = {
+            mergedStateOverrides[entryPoint] = {
+                ...deepHexlify(mergedStateOverrides?.[entryPoint] || {}),
                 stateDiff: {
+                    ...(mergedStateOverrides[entryPoint]?.stateDiff || {}),
                     [slot]: value
                 }
             }

--- a/src/rpc/methods/pimlico_simulateAssetChange.ts
+++ b/src/rpc/methods/pimlico_simulateAssetChange.ts
@@ -54,15 +54,6 @@ export const pimlicoSimulateAssetChangeHandler = createMethodHandler({
             client: rpcHandler.config.publicClient
         })
 
-        let epSimulationsAddress: Address | undefined
-        if (is08) {
-            epSimulationsAddress =
-                rpcHandler.config.entrypointSimulationContractV8
-        } else if (is07) {
-            epSimulationsAddress =
-                rpcHandler.config.entrypointSimulationContractV7
-        }
-
         // Prepare state override based on version
         let stateOverride: StateOverride | undefined
         if (isVersion06(userOp) && rpcHandler.config.codeOverrideSupport) {
@@ -75,7 +66,7 @@ export const pimlicoSimulateAssetChangeHandler = createMethodHandler({
             stateOverride = await prepareSimulationOverrides07({
                 userOp: userOp as UserOperationV07,
                 queuedUserOps: [],
-                epSimulationsAddress: epSimulationsAddress as Address,
+                entryPoint,
                 gasPriceManager: rpcHandler.gasPriceManager,
                 userStateOverrides: stateOverrides,
                 config: rpcHandler.config
@@ -91,13 +82,20 @@ export const pimlicoSimulateAssetChangeHandler = createMethodHandler({
             }[]
 
             if (is08) {
+                if (!rpcHandler.config.entrypointSimulationContractV8) {
+                    throw new RpcError(
+                        "missing entrypointSimulationContractV8",
+                        ValidationErrors.InvalidFields
+                    )
+                }
+
                 // For EntryPoint v0.8
                 const { result: simResult } =
                     await pimlicoSimulation.simulate.simulateAssetChange08(
                         [
                             toPackedUserOp(userOp as UserOperationV07),
                             entryPoint,
-                            epSimulationsAddress as Address,
+                            rpcHandler.config.entrypointSimulationContractV8,
                             addresses,
                             tokens
                         ],
@@ -107,13 +105,20 @@ export const pimlicoSimulateAssetChangeHandler = createMethodHandler({
                     )
                 result = [...simResult]
             } else if (is07) {
+                if (!rpcHandler.config.entrypointSimulationContractV7) {
+                    throw new RpcError(
+                        "missing entrypointSimulationContractV7",
+                        ValidationErrors.InvalidFields
+                    )
+                }
+
                 // For EntryPoint v0.7
                 const { result: simResult } =
                     await pimlicoSimulation.simulate.simulateAssetChange07(
                         [
                             toPackedUserOp(userOp as UserOperationV07),
                             entryPoint,
-                            epSimulationsAddress as Address,
+                            rpcHandler.config.entrypointSimulationContractV7,
                             addresses,
                             tokens
                         ],


### PR DESCRIPTION
the BLOCK_BASE_FEE_PER_GAS override should be made on EntryPoint address instead of EntryPointSimulation because delegateAndRevert uses EntryPoint storage