### PR TITLE
Fix/get receipt

### DIFF
--- a/src/executor/userOpMonitor.ts
+++ b/src/executor/userOpMonitor.ts
@@ -519,10 +519,7 @@ export class UserOpMonitor {
 
                     return transactionReceipt
                 } catch (e) {
-                    if (
-                        e instanceof TransactionReceiptNotFoundError &&
-                        attempt < maxRetries
-                    ) {
+                    if (e instanceof TransactionReceiptNotFoundError) {
                         if (attempt < maxRetries - 1) {
                             // Wait a bit before trying again
                             await new Promise((resolve) =>

--- a/src/executor/userOpMonitor.ts
+++ b/src/executor/userOpMonitor.ts
@@ -490,7 +490,7 @@ export class UserOpMonitor {
         const getTransactionReceipt = async (
             txHash: HexData32
         ): Promise<TransactionReceipt> => {
-            const maxRetries = 10
+            const maxRetries = 16
 
             for (let attempt = 0; attempt < maxRetries; attempt++) {
                 try {
@@ -524,6 +524,10 @@ export class UserOpMonitor {
                         attempt < maxRetries
                     ) {
                         if (attempt < maxRetries - 1) {
+                            // Wait a bit before trying again
+                            await new Promise((resolve) =>
+                                setTimeout(resolve, this.config.blockTime / 4)
+                            )
                             continue
                         }
 

--- a/src/executor/userOpMonitor.ts
+++ b/src/executor/userOpMonitor.ts
@@ -526,9 +526,10 @@ export class UserOpMonitor {
                         if (attempt < maxRetries - 1) {
                             continue
                         }
+
                         // Max retries reached, likely a reorg
                         throw new Error(
-                            `Transaction receipt not found after ${maxRetries} attempts for tx ${txHash} - possible chain reorganization`
+                            `Transaction receipt not found after ${maxRetries} attempts for tx ${txHash}`
                         )
                     }
 


### PR DESCRIPTION
Alto currently fetches receipts in a while(true) loop, there is a edgecase where a block re-orgs and the receipt is never found. In this case Alto will poll the receipt indefinitely 