### PR TITLE
refactor: use viem's getUserOperationHash helper

### DIFF
--- a/src/mempool/mempool.ts
+++ b/src/mempool/mempool.ts
@@ -309,11 +309,10 @@ export class Mempool {
         entryPoint: Address,
         referencedContracts?: ReferencedCodeHashes
     ): Promise<[boolean, string]> {
-        const userOpHash = await getUserOpHash({
+        const userOpHash = getUserOpHash({
             userOp,
             entryPointAddress: entryPoint,
-            chainId: this.config.chainId,
-            publicClient: this.config.publicClient
+            chainId: this.config.chainId
         })
 
         // Check if the userOp is already known or conflicts with existing operations

--- a/src/rpc/methods/eth_sendUserOperation.ts
+++ b/src/rpc/methods/eth_sendUserOperation.ts
@@ -97,21 +97,20 @@ export async function addToMempoolIfValid({
 }): Promise<{ userOpHash: Hex; result: "added" | "queued" }> {
     rpcHandler.ensureEntryPointIsSupported(entryPoint)
 
+    const userOpHash = getUserOpHash({
+        userOp,
+        entryPointAddress: entryPoint,
+        chainId: rpcHandler.config.chainId
+    })
+
     // Execute multiple async operations in parallel
     const [
-        userOpHash,
         { queuedUserOps, validationResult },
         currentNonceSeq,
         [pvgSuccess, pvgErrorReason],
         [preMempoolSuccess, preMempoolError],
         [validEip7702Auth, validEip7702AuthError]
     ] = await Promise.all([
-        getUserOpHash({
-            userOp,
-            entryPointAddress: entryPoint,
-            chainId: rpcHandler.config.chainId,
-            publicClient: rpcHandler.config.publicClient
-        }),
         getUserOpValidationResult(rpcHandler, userOp, entryPoint),
         rpcHandler.getNonceSeq(userOp, entryPoint),
         validatePvg(apiVersion, rpcHandler, userOp, entryPoint, boost),

--- a/src/rpc/methods/pimlico_sendUserOperationNow.ts
+++ b/src/rpc/methods/pimlico_sendUserOperationNow.ts
@@ -28,11 +28,10 @@ export const pimlicoSendUserOperationNowHandler = createMethodHandler({
         const [userOp, entryPoint] = params
         rpcHandler.ensureEntryPointIsSupported(entryPoint)
 
-        const opHash = await getUserOpHash({
+        const userOpHash = getUserOpHash({
             userOp,
             entryPointAddress: entryPoint,
-            chainId: rpcHandler.config.chainId,
-            publicClient: rpcHandler.config.publicClient
+            chainId: rpcHandler.config.chainId
         })
 
         const [preMempoolValid, preMempoolError] =
@@ -45,12 +44,7 @@ export const pimlicoSendUserOperationNowHandler = createMethodHandler({
         // Prepare bundle
         const userOpInfo: UserOpInfo = {
             userOp,
-            userOpHash: await getUserOpHash({
-                userOp,
-                entryPointAddress: entryPoint,
-                chainId: rpcHandler.config.chainId,
-                publicClient: rpcHandler.config.publicClient
-            }),
+            userOpHash,
             addedToMempool: Date.now(),
             submissionAttempts: 0
         }
@@ -92,6 +86,6 @@ export const pimlicoSendUserOperationNowHandler = createMethodHandler({
                 pollingInterval: 100
             })
 
-        return parseUserOpReceipt(opHash, receipt)
+        return parseUserOpReceipt(userOpHash, receipt)
     }
 })

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import type { StateOverrides, UserOperation } from "@alto/types"
-import { BaseError, type RawContractError, concat, getAddress } from "viem"
+import { concat, getAddress } from "viem"
 import type { SignedAuthorization } from "viem"
 
 /// Convert an object to JSON string, handling bigint values
@@ -48,14 +48,6 @@ export const areAddressesEqual = (a: string, b: string) => {
     } catch {
         return false
     }
-}
-
-export function getRevertErrorData(err: unknown) {
-    if (!(err instanceof BaseError)) {
-        return undefined
-    }
-    const error = err.walk() as RawContractError
-    return typeof error?.data === "object" ? error.data?.data : error.data
 }
 
 export function getAAError(errorMsg: string) {

--- a/src/utils/preVerificationGasCalulator.ts
+++ b/src/utils/preVerificationGasCalulator.ts
@@ -38,7 +38,7 @@ import {
 import { isVersion06, isVersion07, toPackedUserOp } from "./userop"
 
 // Encodes a user operation into bytes for gas calculation
-export function encodeUserOp(userOp: UserOperation): Uint8Array {
+function encodeUserOp(userOp: UserOperation): Uint8Array {
     const p = fillUserOpWithDummyData(userOp)
 
     if (isVersion06(userOp)) {
@@ -129,7 +129,7 @@ const defaultOverHeads: GasOverheads = {
     floorPerTokenGasCost: 10n
 }
 
-export function fillUserOpWithDummyData(userOp: UserOperation): UserOperation {
+function fillUserOpWithDummyData(userOp: UserOperation): UserOperation {
     if (isVersion06(userOp)) {
         return {
             ...userOp,


### PR DESCRIPTION
- Replaced custom getUserOpHash implementation with viem's built-in getUserOperationHash function

- Made getUserOpHash synchronous by removing unnecessary publicClient dependency

- Removed duplicate hash calculations and simplified code across mempool and RPC methods

- Made internal helper functions private (encodeUserOp, fillUserOpWithDummyData, etc.)

- Removed unused getRevertErrorData function