### PR TITLE
feat(monad): add reserve balance validation for user operations

### DIFF
--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -144,10 +144,6 @@ export const executorArgsSchema = z.object({
         .string()
         .transform((val) => BigInt(val))
         .default("10"),
-    "arbitrum-gas-bid-multiplier": z
-        .string()
-        .transform((val) => BigInt(val))
-        .default("5"),
     "binary-search-max-retries": z.number().int().min(1).default(3),
     "private-endpoint-submission-attempts": z.number().int().min(0).default(3)
 })
@@ -188,7 +184,15 @@ export const compatibilityArgsSchema = z.object({
         .string()
         .transform((val) => parseGwei(val))
         .optional(),
-    "supports-eip7623": z.boolean().default(false)
+    "supports-eip7623": z.boolean().default(false),
+    "arbitrum-gas-bid-multiplier": z
+        .string()
+        .transform((val) => BigInt(val))
+        .default("5"),
+    "monad-reserve-balance": z
+        .string()
+        .transform((val) => BigInt(val))
+        .default("10000000000000000000")
 })
 
 export const serverArgsSchema = z.object({

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -456,13 +456,6 @@ export const executorOptions: CliCommandOptions<IExecutorArgsInput> = {
         require: false,
         default: "10"
     },
-    "arbitrum-gas-bid-multiplier": {
-        description:
-            "Multiplier for gas bid on Arbitrum networks to account for baseFee fluctuations",
-        type: "string",
-        require: false,
-        default: "5"
-    },
     "binary-search-max-retries": {
         description:
             "Maximum number of retries for binary search operations during gas estimation",
@@ -559,6 +552,20 @@ export const compatibilityOptions: CliCommandOptions<ICompatibilityArgsInput> =
             type: "boolean",
             require: false,
             default: false
+        },
+        "arbitrum-gas-bid-multiplier": {
+            description:
+                "Multiplier for gas bid on Arbitrum networks to account for baseFee fluctuations",
+            type: "string",
+            require: false,
+            default: "5"
+        },
+        "monad-reserve-balance": {
+            description:
+                "Minimum balance (in wei) that must be reserved for Monad chain user operations without paymasters",
+            type: "string",
+            require: false,
+            default: "10000000000000000000"
         }
     }
 

--- a/src/utils/userop.ts
+++ b/src/utils/userop.ts
@@ -284,6 +284,40 @@ export const getNonceKeyAndSequence = (nonce: bigint) => {
     return [nonceKey, nonceSequence]
 }
 
+// Check if a userOperation has a paymaster
+export function hasPaymaster(userOp: UserOperation): boolean {
+    if (isVersion06(userOp)) {
+        return !!userOp.paymasterAndData && userOp.paymasterAndData !== "0x"
+    }
+    return !!userOp.paymaster && userOp.paymaster !== "0x"
+}
+
+export function calculateRequiredPrefund(userOp: UserOperation): bigint {
+    if (isVersion06(userOp)) {
+        const mul = hasPaymaster(userOp) ? 3n : 1n
+        const requiredGas =
+            userOp.callGasLimit +
+            userOp.verificationGasLimit * mul +
+            userOp.preVerificationGas
+
+        return requiredGas * userOp.maxFeePerGas
+    }
+
+    // v0.7/v0.8 logic: sum all gas limits directly
+    const paymasterVerificationGasLimit =
+        userOp.paymasterVerificationGasLimit ?? 0n
+    const paymasterPostOpGasLimit = userOp.paymasterPostOpGasLimit ?? 0n
+
+    const requiredGas =
+        userOp.verificationGasLimit +
+        userOp.callGasLimit +
+        paymasterVerificationGasLimit +
+        paymasterPostOpGasLimit +
+        userOp.preVerificationGas
+
+    return requiredGas * userOp.maxFeePerGas
+}
+
 export function toUnpackedUserOp(
     packedUserOp: PackedUserOperation
 ): UserOperation07 {


### PR DESCRIPTION
- Added monad-reserve-balance config option (default 10 ETH)

- Implemented chain-specific validation to ensure sender maintains minimum balance

- Created hasPaymaster and calculateRequiredPrefund utility functions

- Moved arbitrum-gas-bid-multiplier to compatibility config for consistency
