### PR TITLE
fix(logging): standardize error variable naming in pino logs

### DIFF
--- a/src/executor/bundleManager.ts
+++ b/src/executor/bundleManager.ts
@@ -429,11 +429,11 @@ export class BundleManager {
                     )
                 }, this.config.publicClient.chain.blockTime ?? 1_000)
             })
-        } catch (error) {
+        } catch (err) {
             this.logger.error(
                 {
-                    userOpHash,
-                    error
+                    err,
+                    userOpHash
                 },
                 "Error checking frontrun status"
             )

--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -131,8 +131,8 @@ export class ExecutorManager {
             const intervalId = setInterval(async () => {
                 try {
                     await this.handleBlock()
-                } catch (error) {
-                    this.logger.error({ error }, "error while polling blocks")
+                } catch (err) {
+                    this.logger.error({ err }, "error while polling blocks")
                 }
             }, this.config.flashblocksPreconfirmationTime)
 
@@ -146,8 +146,8 @@ export class ExecutorManager {
                 onBlock: async (block) => {
                     await this.handleBlock(block)
                 },
-                onError: (error) => {
-                    this.logger.error({ error }, "error while watching blocks")
+                onError: (err) => {
+                    this.logger.error({ err }, "error while watching blocks")
                 },
                 includeTransactions: false,
                 emitMissed: false
@@ -493,7 +493,7 @@ export class ExecutorManager {
                     setTimeout(resolve, blockTime / 2)
                 )
             } catch (err) {
-                logger.warn({ error: err }, "failed to cancel bundle")
+                logger.warn({ err }, "failed to cancel bundle")
                 gasMultiplier += 20n // Increase gas by additional 20% each retry
             }
         }

--- a/src/executor/senderManager/flushOnStartUp.ts
+++ b/src/executor/senderManager/flushOnStartUp.ts
@@ -33,8 +33,8 @@ export const flushOnStartUp = async ({
 
     try {
         gasPrice = await gasPriceManager.tryGetNetworkGasPrice()
-    } catch (e) {
-        logger.error({ error: e }, "error flushing stuck transaction")
+    } catch (err) {
+        logger.error({ err }, "error flushing stuck transaction")
         return
     }
 
@@ -46,8 +46,8 @@ export const flushOnStartUp = async ({
                 gasPrice: gasPrice.maxFeePerGas * 5n,
                 logger
             })
-        } catch (e) {
-            logger.error({ error: e }, "error flushing stuck transaction")
+        } catch (err) {
+            logger.error({ err }, "error flushing stuck transaction")
         }
     })
 

--- a/src/executor/utils.ts
+++ b/src/executor/utils.ts
@@ -257,9 +257,9 @@ export async function flushStuckTransaction({
                 { txHash, nonce: nonceToFlush, wallet: wallet.address },
                 "flushed stuck transaction"
             )
-        } catch (e) {
-            sentry.captureException(e)
-            logger.warn({ error: e }, "error flushing stuck transaction")
+        } catch (err) {
+            sentry.captureException(err)
+            logger.warn({ err }, "error flushing stuck transaction")
         }
     }
 }

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -78,8 +78,8 @@ export class GasPriceManager {
                     ? this.tryUpdateBaseFee()
                     : Promise.resolve()
             ])
-        } catch (error) {
-            this.logger.error(error, "Error during gas price initialization")
+        } catch (err) {
+            this.logger.error({ err }, "Error during gas price initialization")
         }
     }
 


### PR DESCRIPTION
- Renamed 'error' variable to 'err' in catch blocks

- Ensured all error logs use structured format {err}

- Updated bundleManager, executorManager, senderManager, and gasPriceManager
