### PR TITLE
refactor(logging): improve logging consistency and reduce redundancy

### DIFF
--- a/src/rpc/estimation/gasEstimations06.ts
+++ b/src/rpc/estimation/gasEstimations06.ts
@@ -74,14 +74,7 @@ export class GasEstimator06 {
             // simulateHandleOp should always revert, if it doesn't something is wrong
             throw new Error("simulateHandleOp did not revert")
         } catch (e) {
-            const decodedError = decodeSimulateHandleOpError(e, this.logger)
-            if (decodedError.result === "failed") {
-                this.logger.warn(
-                    { err: e, data: decodedError.data },
-                    "Contract function reverted in simulateValidation"
-                )
-            }
-            return decodedError
+            return decodeSimulateHandleOpError(e, this.logger)
         }
     }
 }

--- a/src/rpc/estimation/gasEstimations07.ts
+++ b/src/rpc/estimation/gasEstimations07.ts
@@ -237,12 +237,7 @@ export class GasEstimator07 {
                 }
             }
         } catch (error) {
-            const decodedError = decodeSimulateHandleOpError(error, this.logger)
-            this.logger.warn(
-                { err: error, data: decodedError.data },
-                "Contract function reverted in executeSimulateHandleOp"
-            )
-            return decodedError
+            return decodeSimulateHandleOpError(error, this.logger)
         }
     }
 
@@ -385,10 +380,6 @@ export class GasEstimator07 {
             }
         } catch (error) {
             const decodedError = decodeSimulateHandleOpError(error, this.logger)
-            this.logger.warn(
-                { err: error, data: decodedError.data },
-                "Contract function reverted in simulateValidation"
-            )
             return decodedError as {
                 result: "failed"
                 data: string
@@ -435,12 +426,7 @@ export class GasEstimator07 {
                 data: result
             }
         } catch (error) {
-            const decodedError = decodeSimulateHandleOpError(error, this.logger)
-            this.logger.warn(
-                { err: error, data: decodedError.data },
-                "Contract function reverted in simulateValidation"
-            )
-            return decodedError
+            return decodeSimulateHandleOpError(error, this.logger)
         }
     }
 
@@ -492,12 +478,7 @@ export class GasEstimator07 {
                 }
             }
         } catch (error) {
-            const decodedError = decodeSimulateHandleOpError(error, this.logger)
-            this.logger.warn(
-                { err: error, data: decodedError.data },
-                "Contract function reverted in validateHandleOpV07"
-            )
-            return decodedError
+            return decodeSimulateHandleOpError(error, this.logger)
         }
     }
 

--- a/src/rpc/estimation/utils.ts
+++ b/src/rpc/estimation/utils.ts
@@ -210,6 +210,10 @@ export function decodeSimulateHandleOpError(
             )
         }
     } else {
+        logger.warn(
+            { err: contractFunctionRevertedError },
+            "Unknown error, could not parse simulate validation result."
+        )
         throw new Error(
             "Unknown error, could not parse simulate validation result."
         )


### PR DESCRIPTION
- Use childLogger instead of this.logger for scoped error messages in executor

- Rename userOperations to userOps in logger context for consistency

- Remove redundant warning logs from gas estimation error handling

- Centralize error logging in decodeSimulateHandleOpError utility

- Remove opHashes from bundle submission log
