### PR TITLE
fix(estimation): throw error instead of returning error object in binary search

### DIFF
--- a/src/rpc/estimation/gasEstimations07.ts
+++ b/src/rpc/estimation/gasEstimations07.ts
@@ -118,11 +118,7 @@ export class GasEstimator07 {
                 { methodName, retryCount },
                 "Max retries reached in binary search"
             )
-            return {
-                result: "failed",
-                data: `Max retries reached when calling ${methodName}`,
-                code: ERC7769Errors.SimulateValidation
-            }
+            throw new Error(`Max retries reached when calling ${methodName}`)
         }
 
         const packedQueuedOps = packUserOps(queuedUserOps)


### PR DESCRIPTION
- Changed max retries handling to throw Error instead of returning error tuple

- Ensures proper error propagation in gas estimation retry logic
