### PR TITLE
fix(arbitrum): use min l2 base fee in pvg validation

### DIFF
--- a/src/handlers/arbitrumGasPriceManager.ts
+++ b/src/handlers/arbitrumGasPriceManager.ts
@@ -35,6 +35,11 @@ export class ArbitrumManager {
         return maxL1BaseFee || maxUint128
     }
 
+    public async getMinL2BaseFee() {
+        const minL2BaseFee = await this.l2BaseFeeQueue.getMinValue()
+        return minL2BaseFee || 1n
+    }
+
     public async getMaxL2BaseFee() {
         const maxL2BaseFee = await this.l2BaseFeeQueue.getMaxValue()
         return maxL2BaseFee || maxUint128

--- a/src/rpc/estimation/preVerificationGasCalculator.ts
+++ b/src/rpc/estimation/preVerificationGasCalculator.ts
@@ -683,13 +683,15 @@ async function calcArbitrumPvg(
     arbitrumManager.saveL2BaseFee(l2BaseFee)
 
     if (validate) {
-        const [maxL1Fee, minL1Fee, maxL2Fee] = await Promise.all([
-            l1BaseFeeEstimate || arbitrumManager.getMaxL1BaseFee(),
-            arbitrumManager.getMinL1BaseFee(),
-            arbitrumManager.getMaxL2BaseFee()
-        ])
+        const [maxL1Fee, minL1Fee, maxL2BaseFee, minL2BaseFee] =
+            await Promise.all([
+                l1BaseFeeEstimate || arbitrumManager.getMaxL1BaseFee(),
+                arbitrumManager.getMinL1BaseFee(),
+                arbitrumManager.getMaxL2BaseFee(),
+                arbitrumManager.getMinL2BaseFee()
+            ])
 
-        return (gasForL1 * l2BaseFee * minL1Fee) / (maxL1Fee * maxL2Fee)
+        return (gasForL1 * minL2BaseFee * minL1Fee) / (maxL1Fee * maxL2BaseFee)
     }
 
     return gasForL1


### PR DESCRIPTION
- Added getMinL2BaseFee method to ArbitrumManager

- Updated validation calculation to use both min and max L2 base fees
