### PR TITLE
feat(gas): add static max priority fee override option

### DIFF
--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -166,7 +166,11 @@ export const compatibilityArgsSchema = z.object({
         .string()
         .transform((val) => parseGwei(val))
         .optional(),
-    "override-max-priority-fee-per-gas": z
+    "ceiling-max-fee-per-gas": z
+        .string()
+        .transform((val) => parseGwei(val))
+        .optional(),
+    "ceiling-max-priority-fee-per-gas": z
         .string()
         .transform((val) => parseGwei(val))
         .optional(),

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -540,9 +540,14 @@ export const compatibilityOptions: CliCommandOptions<ICompatibilityArgsInput> =
             type: "string",
             require: false
         },
-        "override-max-priority-fee-per-gas": {
+        "ceiling-max-fee-per-gas": {
+            description: "Maximum value for maxFeePerGas to enforce (in gwei)",
+            type: "string",
+            require: false
+        },
+        "ceiling-max-priority-fee-per-gas": {
             description:
-                "Override the chain's maxPriorityFeePerGas estimation with a static value (in gwei)",
+                "Maximum value for maxPriorityFeePerGas to enforce (in gwei)",
             type: "string",
             require: false
         },

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -137,6 +137,20 @@ export class GasPriceManager {
             )
         }
 
+        // Apply ceiling values if configured
+        if (this.config.ceilingMaxPriorityFeePerGas) {
+            maxPriorityFeePerGas = minBigInt(
+                maxPriorityFeePerGas,
+                this.config.ceilingMaxPriorityFeePerGas
+            )
+        }
+        if (this.config.ceilingMaxFeePerGas) {
+            maxFeePerGas = minBigInt(
+                maxFeePerGas,
+                this.config.ceilingMaxFeePerGas
+            )
+        }
+
         return {
             // Ensure that maxFeePerGas is always greater or equal than maxPriorityFeePerGas
             maxFeePerGas: maxBigInt(maxFeePerGas, maxPriorityFeePerGas),
@@ -201,14 +215,7 @@ export class GasPriceManager {
         let maxFeePerGas: bigint | undefined
         let maxPriorityFeePerGas: bigint | undefined
 
-        const { publicClient, overrideMaxPriorityFeePerGas } = this.config
-
-        // Override maxPriorityFeePerGas if configured
-        if (overrideMaxPriorityFeePerGas) {
-            publicClient.chain.fees = {
-                maxPriorityFeePerGas: overrideMaxPriorityFeePerGas
-            }
-        }
+        const publicClient = this.config.publicClient
 
         try {
             const fees = await publicClient.estimateFeesPerGas()

--- a/src/types/gasPrice.ts
+++ b/src/types/gasPrice.ts
@@ -1,23 +1,3 @@
-// {"safeLow":{"maxPriorityFee":32.70666665266667,"maxFee":32.70666666866667},"standard":{"maxPriorityFee":33.10666665266667,"maxFee":33.10666666866667},"fast":{"maxPriorityFee":34.54799998386667,"maxFee":34.54799999986667},"estimatedBaseFee":1.6e-8,"blockTime":2,"blockNumber":36422482}
-
-// {
-//     "safeLow": {
-//       "maxPriorityFee": 10.474218399333333,
-//       "maxFee": 10.474218415333333
-//     },
-//     "standard": {
-//       "maxPriorityFee": 10.674218398266666,
-//       "maxFee": 10.674218414266665
-//     },
-//     "fast": {
-//       "maxPriorityFee": 15.771550529,
-//       "maxFee": 15.771550545
-//     },
-//     "estimatedBaseFee": 1.6e-08,
-//     "blockTime": 2,
-//     "blockNumber": 36422513
-//   }
-
 import { parseGwei } from "viem"
 import { bigint, z } from "zod"
 


### PR DESCRIPTION
- Added --override-max-priority-fee-per-gas CLI option for static priority fee

- Refactored gas price bumping to use scaleBigIntByPercent utility

- Simplified gas price calculation logic by removing redundant operations

- Removed unused getDefaultGasFee method
