### PR TITLE
Fix build pipeline by adding build:all to ensure contracts compile before TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a full explanation of Alto, please visit our [docs page](https://docs.pimlic
 #### Run an instance of Alto with the following commands:
 ```bash
 pnpm install
-pnpm build
+pnpm build:all
 ./alto --entrypoints "0x5ff1...2789,0x0000...a032" --executor-private-keys "..." --utility-private-key "..." --min-balance "0" --rpc-url "http://localhost:8545" --network-name "local"
 ```
 To find a list of all options, run:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "clean": "rimraf ./src/esm ./src/*.tsbuildinfo",
         "clean-modules": "rimraf ./src/node_modules node_modules",
         "build": "pnpm run clean && pnpm run -r build",
+        "build:all": "pnpm run build:contracts && pnpm run build",
         "build:contracts:PimlicoSimulations": "forge build --quiet --root contracts --evm-version london --out ../src/contracts/ src/PimlicoSimulations.sol ",
         "build:contracts:EPFilterOpsOverride06": "forge build --quiet --root contracts --evm-version london --optimize --optimizer-runs 1000000 --via-ir --use solc:0.8.17 --out ../src/contracts/ src/v06/EntryPointFilterOpsOverride.sol",
         "build:contracts:EPFilterOpsOverride07": "forge build --quiet --root contracts --evm-version paris --optimize --optimizer-runs 1000000 --via-ir --use solc:0.8.23 --out ../src/contracts/ src/v07/EntryPointFilterOpsOverride.sol",


### PR DESCRIPTION

This PR updates the build process to run contract compilation before the main TypeScript build.
It adds a `build:all` script (`pnpm run build:contracts && pnpm run build`) to resolve missing module path errors caused by uncompiled contract artifacts.
