### PR TITLE
chore(config): update arbitrum gas multiplier default to 150

### DIFF
--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -570,7 +570,7 @@ export const compatibilityOptions: CliCommandOptions<ICompatibilityArgsInput> =
                 "Multiplier for gas bids on Arbitrum networks to account for baseFee fluctuations",
             type: "string",
             require: false,
-            default: "5"
+            default: "150"
         },
         "monad-reserve-balance": {
             description:


### PR DESCRIPTION
- Changed arbitrum-gas-multiplier default from 5 to 150

- Improves gas bid calculation for baseFee fluctuations on Arbitrum
