### PR TITLE
fix(gas): increase max gas override for estimation

### DIFF
--- a/src/rpc/methods/eth_estimateUserOperationGas.ts
+++ b/src/rpc/methods/eth_estimateUserOperationGas.ts
@@ -151,7 +151,7 @@ const getGasEstimates = async ({
 
         // gas estimation simulation is done with maxFeePerGas/maxPriorityFeePerGas = 1.
         // Because of this, sender must have atleast maxGas of wei.
-        const maxGas = parseEther("100")
+        const maxGas = parseEther("100000000")
 
         mutableStateOverrides[sender] = {
             ...deepHexlify(mutableStateOverrides[sender] || {}),


### PR DESCRIPTION
- Increased maxGas from 100 ETH to 100,000,000 ETH to handle cases where userOp.sender has >100 ETH of balance
