### PR TITLE
fix(executor): detect erigon underpriced tx error

### DIFF
--- a/src/executor/utils.ts
+++ b/src/executor/utils.ts
@@ -70,11 +70,13 @@ export const getBundleGasLimit = async ({
 }
 
 export const isTransactionUnderpricedError = (e: BaseError) => {
-    const transactionUnderPriceError = e.walk((e: any) =>
-        e?.message
-            ?.toLowerCase()
-            .includes("replacement transaction underpriced")
-    )
+    const transactionUnderPriceError = e.walk((e: any) => {
+        const message = e?.message?.toLowerCase()
+        return (
+            message?.includes("replacement transaction underpriced") || // Geth error message
+            message?.includes("could not replace existing tx") // Erigon error message
+        )
+    })
     return transactionUnderPriceError !== null
 }
 


### PR DESCRIPTION
- Add 'could not replace existing tx' as underpriced error
