### PR TITLE
chore(ci): enable npm trusted publisher

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -41,4 +41,4 @@ jobs:
           pnpm run build:contracts && pnpm run build && jq '. + {type: "module"}' ./src/package.json > ./src/package.tmp.json && mv ./src/package.tmp.json ./src/package.json
 
       - name: Publish alto to npm
-        run: cd src && npm publish --provenance --access public --tag $(git branch --show-current | tr -cs '[:alnum:]-' '-' | tr '[:upper:]' '[:lower:]' | sed 's/-$//')
+        run: cd src && npm publish --access public --tag $(git branch --show-current | tr -cs '[:alnum:]-' '-' | tr '[:upper:]' '[:lower:]' | sed 's/-$//')

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "lint:fix": "pnpm run lint --apply",
         "format": "biome format . --write",
         "changeset": "changeset",
-        "changeset:release": "changeset publish --provenance",
+        "changeset:release": "changeset publish",
         "changeset:version": "changeset version && pnpm install --lockfile-only"
     },
     "devDependencies": {


### PR DESCRIPTION
- Add id-token permissions to canary workflow
- Upgrade actions/setup-node to v4
- Add --provenance flag to npm publish commands
- Add npm registry setup step to release workflow
