### PR TITLE
fix(gas): eliminate redis timing drift with PTTL-based polling

### DIFF
--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -417,7 +417,7 @@ export class GasPriceManager {
     private scheduleRefresh(delayMs: number): void {
         setTimeout(async () => {
             const nextDelayMs = await this.refreshGasPrices()
-            this.scheduleRefresh(Math.max(nextDelayMs, 100))
+            this.scheduleRefresh(nextDelayMs)
         }, delayMs).unref()
     }
 
@@ -452,7 +452,13 @@ export class GasPriceManager {
                         .pttl(this.redisRefreshGuard.key)
                         .catch(() => refreshIntervalMs / 2)
 
-                    return Math.max(pttl, 100)
+                    // PTTL returns -2 when the key already expired —
+                    // retry immediately with a 100ms floor to avoid tight-looping.
+                    if (pttl < 0) {
+                        return 100
+                    }
+
+                    return pttl
                 }
             }
 

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -66,10 +66,13 @@ export class GasPriceManager {
 
         // Periodically update gas prices if specified
         if (this.config.gasPriceRefreshInterval > 0) {
-            setInterval(
-                () => this.refreshGasPrices(),
-                this.config.gasPriceRefreshInterval * 1000
-            )
+            // Poll at half the refresh interval. The Redis lock
+            // (TTL = gasPriceRefreshInterval) ensures only one instance
+            // succeeds per refresh window. Polling at the same rate as the
+            // lock TTL causes missed cycles due to millisecond drift
+            // between setInterval firing and lock expiry.
+            const pollingInterval = (this.config.gasPriceRefreshInterval * 1000) / 2
+            setInterval(() => this.refreshGasPrices(), pollingInterval)
         }
 
         this.arbitrumManager = new ArbitrumManager({ config })

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -446,8 +446,8 @@ export class GasPriceManager {
                     })
 
                 if (acquired !== "OK") {
-                    // Another instance holds the lock — check remaining TTL
-                    // and retry after it expires.
+                    // Another instance holds the lock — return remaining TTL
+                    // so the caller can retry after it expires.
                     const pttl = await this.redisRefreshGuard.redis
                         .pttl(this.redisRefreshGuard.key)
                         .catch(() => refreshIntervalMs / 2)

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -66,14 +66,7 @@ export class GasPriceManager {
 
         // Periodically update gas prices if specified
         if (this.config.gasPriceRefreshInterval > 0) {
-            // Poll at half the refresh interval. The Redis lock
-            // (TTL = gasPriceRefreshInterval) ensures only one instance
-            // succeeds per refresh window. Polling at the same rate as the
-            // lock TTL causes missed cycles due to millisecond drift
-            // between setInterval firing and lock expiry.
-            const pollingInterval =
-                (this.config.gasPriceRefreshInterval * 1000) / 2
-            setInterval(() => this.refreshGasPrices(), pollingInterval)
+            this.scheduleRefresh(0)
         }
 
         this.arbitrumManager = new ArbitrumManager({ config })
@@ -421,7 +414,22 @@ export class GasPriceManager {
         return this.bumpTheGasPrice(estimatedGasPrice)
     }
 
-    private async refreshGasPrices(): Promise<void> {
+    private scheduleRefresh(delayMs: number): void {
+        const timeout = setTimeout(async () => {
+            const nextDelayMs = await this.refreshGasPrices()
+            this.scheduleRefresh(Math.max(nextDelayMs, 100))
+        }, delayMs)
+
+        // Allow process to exit even if timeout is pending
+        if (timeout.unref) {
+            timeout.unref()
+        }
+    }
+
+    // Returns the number of milliseconds to sleep before the next poll.
+    private async refreshGasPrices(): Promise<number> {
+        const refreshIntervalMs = this.config.gasPriceRefreshInterval * 1000
+
         try {
             // With horizontal scaling, use a Redis SET NX lock so only one instance
             // makes RPC calls per refresh interval. Fail-open on Redis errors.
@@ -430,8 +438,8 @@ export class GasPriceManager {
                     .set(
                         this.redisRefreshGuard.key,
                         "1",
-                        "EX",
-                        this.config.gasPriceRefreshInterval,
+                        "PX",
+                        refreshIntervalMs,
                         "NX"
                     )
                     .catch((err: unknown) => {
@@ -443,7 +451,13 @@ export class GasPriceManager {
                     })
 
                 if (acquired !== "OK") {
-                    return
+                    // Another instance holds the lock — check remaining TTL
+                    // and retry after it expires.
+                    const pttl = await this.redisRefreshGuard.redis
+                        .pttl(this.redisRefreshGuard.key)
+                        .catch(() => refreshIntervalMs / 2)
+
+                    return Math.max(pttl, 100)
                 }
             }
 
@@ -457,6 +471,8 @@ export class GasPriceManager {
             this.logger.error({ err }, "Error updating gas prices in interval")
             sentry.captureException(err)
         }
+
+        return refreshIntervalMs
     }
 
     // This method throws if it can't get a valid RPC response.

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -71,7 +71,8 @@ export class GasPriceManager {
             // succeeds per refresh window. Polling at the same rate as the
             // lock TTL causes missed cycles due to millisecond drift
             // between setInterval firing and lock expiry.
-            const pollingInterval = (this.config.gasPriceRefreshInterval * 1000) / 2
+            const pollingInterval =
+                (this.config.gasPriceRefreshInterval * 1000) / 2
             setInterval(() => this.refreshGasPrices(), pollingInterval)
         }
 

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -415,15 +415,10 @@ export class GasPriceManager {
     }
 
     private scheduleRefresh(delayMs: number): void {
-        const timeout = setTimeout(async () => {
+        setTimeout(async () => {
             const nextDelayMs = await this.refreshGasPrices()
             this.scheduleRefresh(Math.max(nextDelayMs, 100))
-        }, delayMs)
-
-        // Allow process to exit even if timeout is pending
-        if (timeout.unref) {
-            timeout.unref()
-        }
+        }, delayMs).unref()
     }
 
     // Returns the number of milliseconds to sleep before the next poll.

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -447,7 +447,7 @@ export class GasPriceManager {
 
                 if (acquired !== "OK") {
                     // Another instance holds the lock — return remaining TTL
-                    // so the caller can retry after it expires.
+                    // so that the next call to refreshGasPrices can try again
                     const pttl = await this.redisRefreshGuard.redis
                         .pttl(this.redisRefreshGuard.key)
                         .catch(() => refreshIntervalMs / 2)

--- a/src/utils/minMaxQueue/createRedisMinMaxQueue.ts
+++ b/src/utils/minMaxQueue/createRedisMinMaxQueue.ts
@@ -31,7 +31,6 @@ class SortedTtlSet {
     redis: Redis
     redisKey: string // Single sorted set: score = timestamp, member = value
     queueValidity: number
-    refreshInterval: number
     private cleanupInterval: NodeJS.Timeout | null = null
 
     constructor({
@@ -49,7 +48,6 @@ class SortedTtlSet {
         this.redis = redis
         this.redisKey = `${config.redisKeyPrefix}:${config.chainId}:${queueName}`
         this.queueValidity = queueValidity
-        this.refreshInterval = config.gasPriceRefreshInterval
 
         // Start background cleanup every minute
         this.startBackgroundCleanup()
@@ -96,10 +94,7 @@ class SortedTtlSet {
     }
 
     private getValidCutoffTime(): number {
-        // A value served to a user could have been written up to one
-        // refresh interval earlier. Extend the window to guarantee
-        // users get the full gasPriceExpiry from when they read the value.
-        return Date.now() / 1_000 - this.queueValidity - this.refreshInterval
+        return Date.now() / 1_000 - this.queueValidity
     }
 
     async getMin(logger: Logger): Promise<bigint | null> {

--- a/src/utils/minMaxQueue/createRedisMinMaxQueue.ts
+++ b/src/utils/minMaxQueue/createRedisMinMaxQueue.ts
@@ -31,6 +31,7 @@ class SortedTtlSet {
     redis: Redis
     redisKey: string // Single sorted set: score = timestamp, member = value
     queueValidity: number
+    refreshInterval: number
     private cleanupInterval: NodeJS.Timeout | null = null
 
     constructor({
@@ -48,6 +49,7 @@ class SortedTtlSet {
         this.redis = redis
         this.redisKey = `${config.redisKeyPrefix}:${config.chainId}:${queueName}`
         this.queueValidity = queueValidity
+        this.refreshInterval = config.gasPriceRefreshInterval
 
         // Start background cleanup every minute
         this.startBackgroundCleanup()
@@ -94,7 +96,10 @@ class SortedTtlSet {
     }
 
     private getValidCutoffTime(): number {
-        return Date.now() / 1_000 - this.queueValidity
+        // A value served to a user could have been written up to one
+        // refresh interval earlier. Extend the window to guarantee
+        // users get the full gasPriceExpiry from when they read the value.
+        return Date.now() / 1_000 - this.queueValidity - this.refreshInterval
     }
 
     async getMin(logger: Logger): Promise<bigint | null> {


### PR DESCRIPTION
- Replace fixed `setInterval` with adaptive `setTimeout` chain that sleeps for the lock's remaining TTL (via `PTTL`), so instances retry as soon as the lock expires instead of drifting a full interval behind

- Switch Redis lock from `EX` (seconds) to `PX` (milliseconds) to align units with the sleep duration