### PR TITLE
fix(eip7702): validate factory field with eip7702 requirements

### DIFF
--- a/src/rpc/methods/eth_estimateUserOperationGas.ts
+++ b/src/rpc/methods/eth_estimateUserOperationGas.ts
@@ -285,17 +285,13 @@ export const ethEstimateUserOperationGasHandler = createMethodHandler({
         } = rpcHandler.config
 
         // Validate userOp fields (sync - fail fast before async checks)
-        const [fieldsValid, fieldsError] =
-            rpcHandler.validateUserOpFields({
-                userOp,
-                entryPoint,
-                isEstimation: true
-            })
+        const [fieldsValid, fieldsError] = rpcHandler.validateUserOpFields({
+            userOp,
+            entryPoint,
+            isEstimation: true
+        })
         if (!fieldsValid) {
-            throw new RpcError(
-                fieldsError,
-                ERC7769Errors.InvalidFields
-            )
+            throw new RpcError(fieldsError, ERC7769Errors.InvalidFields)
         }
 
         // Execute multiple async operations in parallel

--- a/src/rpc/methods/eth_estimateUserOperationGas.ts
+++ b/src/rpc/methods/eth_estimateUserOperationGas.ts
@@ -284,6 +284,20 @@ export const ethEstimateUserOperationGasHandler = createMethodHandler({
             chainType
         } = rpcHandler.config
 
+        // Validate userOp fields (sync - fail fast before async checks)
+        const [fieldsValid, fieldsError] =
+            rpcHandler.validateUserOpFields({
+                userOp,
+                entryPoint,
+                isEstimation: true
+            })
+        if (!fieldsValid) {
+            throw new RpcError(
+                fieldsError,
+                ERC7769Errors.InvalidFields
+            )
+        }
+
         // Execute multiple async operations in parallel
         const [
             [validEip7702Auth, validEip7702AuthError],

--- a/src/rpc/rpcHandler.ts
+++ b/src/rpc/rpcHandler.ts
@@ -158,8 +158,7 @@ export class RpcHandler {
             !userOp.eip7702Auth &&
             isVersion07(userOp) &&
             (userOp.factory === "0x7702" ||
-                userOp.factory ===
-                    "0x7702000000000000000000000000000000000000")
+                userOp.factory === "0x7702000000000000000000000000000000000000")
         ) {
             return [
                 false,

--- a/src/rpc/rpcHandler.ts
+++ b/src/rpc/rpcHandler.ts
@@ -145,12 +145,33 @@ export class RpcHandler {
     validateUserOpFields({
         userOp,
         entryPoint,
-        isBoosted = false
+        isBoosted = false,
+        isEstimation = false
     }: {
         userOp: UserOperation
         entryPoint: Address
         isBoosted?: boolean
+        isEstimation?: boolean
     }): [boolean, string] {
+        // Check for 0x7702 factory without eip7702Auth
+        if (
+            !userOp.eip7702Auth &&
+            isVersion07(userOp) &&
+            (userOp.factory === "0x7702" ||
+                userOp.factory ===
+                    "0x7702000000000000000000000000000000000000")
+        ) {
+            return [
+                false,
+                "Invalid EIP-7702 userOperation: factory is 0x7702 but eip7702Auth is not provided."
+            ]
+        }
+
+        // Skip gas/field checks during estimation
+        if (isEstimation) {
+            return [true, ""]
+        }
+
         // Validate paymaster signature for EntryPoint 0.9
         const paymasterSignatureError = validatePaymasterSignature({
             userOp,
@@ -246,17 +267,6 @@ export class RpcHandler {
         [boolean, string]
     > {
         if (!userOp.eip7702Auth) {
-            if (
-                isVersion07(userOp) &&
-                (userOp.factory === "0x7702" ||
-                    userOp.factory ===
-                        "0x7702000000000000000000000000000000000000")
-            ) {
-                return [
-                    false,
-                    "Invalid EIP-7702 userOperation: factory is 0x7702 but eip7702Auth is not provided."
-                ]
-            }
             return [true, ""]
         }
 

--- a/src/rpc/rpcHandler.ts
+++ b/src/rpc/rpcHandler.ts
@@ -246,6 +246,17 @@ export class RpcHandler {
         [boolean, string]
     > {
         if (!userOp.eip7702Auth) {
+            if (
+                isVersion07(userOp) &&
+                (userOp.factory === "0x7702" ||
+                    userOp.factory ===
+                        "0x7702000000000000000000000000000000000000")
+            ) {
+                return [
+                    false,
+                    "Invalid EIP-7702 userOperation: factory is 0x7702 but eip7702Auth is missing."
+                ]
+            }
             return [true, ""]
         }
 
@@ -341,11 +352,12 @@ export class RpcHandler {
         if (
             isVersion07(userOp) &&
             userOp.factory !== "0x7702" &&
+            userOp.factory !== "0x7702000000000000000000000000000000000000" &&
             userOp.factory !== null
         ) {
             return [
                 false,
-                "Invalid EIP-7702 authorization: UserOperation cannot contain factory that is neither null or 0x7702."
+                "Invalid EIP-7702 authorization: factory must be null or 0x7702."
             ]
         }
 

--- a/src/rpc/rpcHandler.ts
+++ b/src/rpc/rpcHandler.ts
@@ -160,6 +160,20 @@ export class RpcHandler {
             return [false, paymasterSignatureError]
         }
 
+        // Reject userOps with factory 0x7702 but no eip7702Auth
+        if (
+            isVersion07(userOp) &&
+            !userOp.eip7702Auth &&
+            (userOp.factory === "0x7702" ||
+                userOp.factory ===
+                    "0x7702000000000000000000000000000000000000")
+        ) {
+            return [
+                false,
+                "Invalid EIP-7702 userOperation: factory is 0x7702 but eip7702Auth is not provided."
+            ]
+        }
+
         if (
             this.config.legacyTransactions &&
             userOp.maxFeePerGas !== userOp.maxPriorityFeePerGas
@@ -254,7 +268,7 @@ export class RpcHandler {
             ) {
                 return [
                     false,
-                    "Invalid EIP-7702 userOperation: factory is 0x7702 but eip7702Auth is missing."
+                    "Invalid EIP-7702 userOperation: factory is 0x7702 but eip7702Auth is not provided."
                 ]
             }
             return [true, ""]

--- a/src/rpc/rpcHandler.ts
+++ b/src/rpc/rpcHandler.ts
@@ -165,8 +165,7 @@ export class RpcHandler {
             isVersion07(userOp) &&
             !userOp.eip7702Auth &&
             (userOp.factory === "0x7702" ||
-                userOp.factory ===
-                    "0x7702000000000000000000000000000000000000")
+                userOp.factory === "0x7702000000000000000000000000000000000000")
         ) {
             return [
                 false,

--- a/src/rpc/rpcHandler.ts
+++ b/src/rpc/rpcHandler.ts
@@ -160,19 +160,6 @@ export class RpcHandler {
             return [false, paymasterSignatureError]
         }
 
-        // Reject userOps with factory 0x7702 but no eip7702Auth
-        if (
-            isVersion07(userOp) &&
-            !userOp.eip7702Auth &&
-            (userOp.factory === "0x7702" ||
-                userOp.factory === "0x7702000000000000000000000000000000000000")
-        ) {
-            return [
-                false,
-                "Invalid EIP-7702 userOperation: factory is 0x7702 but eip7702Auth is not provided."
-            ]
-        }
-
         if (
             this.config.legacyTransactions &&
             userOp.maxFeePerGas !== userOp.maxPriorityFeePerGas

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -397,13 +397,18 @@ describe.each([
                     return
                 }
 
-                const client = await getSmartAccountClient({
+                const bundlerClient = createBundlerClient({
+                    chain: foundry,
+                    transport: http(altoRpc)
+                })
+
+                const smartAccountClient = await getSmartAccountClient({
                     entryPointVersion,
                     anvilRpc,
                     altoRpc
                 })
 
-                const op = (await client.prepareUserOperation({
+                const op = (await smartAccountClient.prepareUserOperation({
                     calls: [
                         {
                             to: zeroAddress,
@@ -417,7 +422,10 @@ describe.each([
                 op.factoryData = undefined
 
                 try {
-                    await client.estimateUserOperationGas(op)
+                    await bundlerClient.estimateUserOperationGas({
+                        ...op,
+                        entryPointAddress: entryPoint
+                    })
                     expect.fail("Must throw")
                 } catch (err) {
                     expect(err).toBeInstanceOf(BaseError)

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -379,6 +379,63 @@ describe.each([
             )
         })
 
+        test.each([
+            {
+                testName: "short form (0x7702)",
+                factory: "0x7702"
+            },
+            {
+                testName:
+                    "zero-padded form (0x7702000000000000000000000000000000000000)",
+                factory: "0x7702000000000000000000000000000000000000"
+            }
+        ])(
+            "Should reject estimation with factory $testName but no eip7702Auth",
+            async ({ factory }) => {
+                // Skip for v0.6 - doesn't have factory field
+                if (entryPointVersion === "0.6") {
+                    return
+                }
+
+                const client = await getSmartAccountClient({
+                    entryPointVersion,
+                    anvilRpc,
+                    altoRpc
+                })
+
+                const op = (await client.prepareUserOperation({
+                    calls: [
+                        {
+                            to: zeroAddress,
+                            data: "0x"
+                        }
+                    ]
+                })) as UserOperation
+
+                // Set factory to 0x7702 without providing eip7702Auth
+                op.factory = factory
+                op.factoryData = undefined
+
+                try {
+                    await client.estimateUserOperationGas(op)
+                    expect.fail("Must throw")
+                } catch (err) {
+                    expect(err).toBeInstanceOf(BaseError)
+                    const error = err as BaseError
+
+                    expect(error.details).toMatch(
+                        /factory is 0x7702 but eip7702Auth is not provided/i
+                    )
+
+                    const rpcError = error.walk(
+                        (e) => e instanceof RpcRequestError
+                    ) as RpcRequestError
+                    expect(rpcError).toBeDefined()
+                    expect(rpcError.code).toBe(ERC7769Errors.InvalidFields)
+                }
+            }
+        )
+
         test("Should throw AA25 when estimating userOp with nonce + 1", async () => {
             const smartAccountClient = await getSmartAccountClient({
                 entryPointVersion,

--- a/test/e2e/tests/eth_sendUserOperation.test.ts
+++ b/test/e2e/tests/eth_sendUserOperation.test.ts
@@ -535,6 +535,66 @@ describe.each([
 
         test.each([
             {
+                testName: "short form (0x7702)",
+                factory: "0x7702"
+            },
+            {
+                testName:
+                    "zero-padded form (0x7702000000000000000000000000000000000000)",
+                factory: "0x7702000000000000000000000000000000000000"
+            }
+        ])(
+            "Should reject userOp with factory $testName but no eip7702Auth",
+            async ({ factory }) => {
+                // Skip for v0.6 - doesn't have factory field
+                if (entryPointVersion === "0.6") {
+                    return
+                }
+
+                const client = await getSmartAccountClient({
+                    entryPointVersion,
+                    anvilRpc,
+                    altoRpc
+                })
+
+                const op = (await client.prepareUserOperation({
+                    calls: [
+                        {
+                            to: TO_ADDRESS,
+                            value: VALUE,
+                            data: "0x"
+                        }
+                    ]
+                })) as UserOperation
+
+                // Set factory to 0x7702 without providing eip7702Auth
+                op.factory = factory
+                op.factoryData = undefined
+
+                op.signature = await client.account.signUserOperation(op)
+
+                try {
+                    await client.sendUserOperation(op)
+                    expect.fail("Must throw")
+                } catch (err) {
+                    expect(err).toBeInstanceOf(BaseError)
+                    const error = err as BaseError
+
+                    expect(error.details).toMatch(
+                        /factory is 0x7702 but eip7702Auth is not provided/i
+                    )
+
+                    const rpcError = error.walk(
+                        (e) => e instanceof RpcRequestError
+                    ) as RpcRequestError
+                    expect(rpcError).toBeDefined()
+                    expect(rpcError.code).toBe(ERC7769Errors.InvalidFields)
+                }
+            }
+        )
+
+        test.each([
+            {
                 testName: "r is zero",
                 field: "r" as const,
                 value: "0x0" as Hex


### PR DESCRIPTION
- Add validation for 0x7702 factory address in both short and padded
forms

- Require eip7702Auth when factory is set to 0x7702

- Add comprehensive test coverage for both factory address formats
