### PR TITLE
feat(cli): add gas reward percentiles

### DIFF
--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -50,6 +50,24 @@ export const bundlerArgsSchema = z.object({
         .int()
         .min(1)
         .default(3),
+    "dynamic-gas-price-reward-percentiles": z
+        .string()
+        .transform((value) =>
+            value.split(",").map((item) => Number(item.trim()))
+        )
+        .refine(
+            (values) => values.length === 4,
+            "Must contain 4 comma separated items"
+        )
+        .refine(
+            (values) => values.every((value) => Number.isInteger(value)),
+            "All reward percentiles must be integers"
+        )
+        .refine(
+            (values) => values.every((value) => value >= 0 && value <= 100),
+            "All reward percentiles must be between 0 and 100"
+        )
+        .default("40,50,60,70"),
 
     "mempool-max-parallel-ops": z.number().int().min(0).default(10),
     "mempool-max-queued-ops": z.number().int().min(0).default(0),

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -96,6 +96,13 @@ export const bundlerOptions: CliCommandOptions<IBundlerArgsInput> = {
         require: false,
         default: 3
     },
+    "dynamic-gas-price-reward-percentiles": {
+        description:
+            "Four comma-separated reward percentiles to use for dynamic gas price calculation",
+        type: "string",
+        require: false,
+        default: "40,50,60,70"
+    },
     "mempool-max-parallel-ops": {
         description:
             "Maximum amount of parallel user ops to keep in the meempool (same sender, different nonce keys)",

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -81,7 +81,9 @@ export class GasPriceManager {
                 {
                     lookbackBlocks: this.config.dynamicGasPriceLookbackBlocks,
                     targetInclusionBlocks:
-                        this.config.dynamicGasPriceTargetInclusionBlocks
+                        this.config.dynamicGasPriceTargetInclusionBlocks,
+                    rewardPercentiles:
+                        this.config.dynamicGasPriceRewardPercentiles
                 },
                 "using dynamic gas pricing"
             )
@@ -293,13 +295,14 @@ export class GasPriceManager {
             const {
                 publicClient,
                 dynamicGasPriceLookbackBlocks,
-                dynamicGasPriceTargetInclusionBlocks
+                dynamicGasPriceTargetInclusionBlocks,
+                dynamicGasPriceRewardPercentiles
             } = this.config
 
             const blockCount = dynamicGasPriceLookbackBlocks
             const targetInclusionBlocks = dynamicGasPriceTargetInclusionBlocks
 
-            const rewardPercentiles = [40, 50, 60, 70]
+            const rewardPercentiles = dynamicGasPriceRewardPercentiles
 
             const feeHistory = await publicClient.getFeeHistory({
                 blockCount,


### PR DESCRIPTION
- add a CLI option for dynamic gas reward percentiles

- wire the configured percentiles into gas price history lookup
