### PR TITLE
fix: correct RPC GET response typo

### DIFF
--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -141,7 +141,7 @@ export class Server {
                         await reply
                             .status(404)
                             .send(
-                                `GET request to /${version}/rpc is not supported, use POST isntead`
+                                `GET request to /${version}/rpc is not supported, use POST instead`
                             )
                     },
                     wsHandler: (socket: WebSocket.WebSocket, request) => {


### PR DESCRIPTION
Fixes a typo in the HTTP response returned for unsupported GET requests to the versioned RPC endpoint.

The message now says `instead` instead of `isntead`.

Checked with:
- `git diff --check`
- `pnpm exec biome check src/rpc/server.ts` (passes for this file with existing repository warnings only)

I also tried `pnpm --filter @pimlico/alto build`, but this checkout is missing generated contract JSON artifacts under `src/contracts/...`, so the build is blocked before this typo-only change is relevant.