### PR TITLE
fix(cli): lower user op gas limit

### DIFF
--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -73,7 +73,7 @@ export const bundlerArgsSchema = z.object({
     "mempool-max-queued-ops": z.number().int().min(0).default(0),
     "enforce-unique-senders-per-bundle": z.boolean().default(true),
     "max-gas-per-user-op": z.string().transform(BigInt).default("10000000"),
-    "max-gas-per-bundle": z.string().transform(BigInt).default("20000000"),
+    "max-gas-per-bundle": z.string().transform(BigInt).default("16000000"),
     "rpc-methods": z
         .string()
         .nullable()

--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -72,7 +72,7 @@ export const bundlerArgsSchema = z.object({
     "mempool-max-parallel-ops": z.number().int().min(0).default(10),
     "mempool-max-queued-ops": z.number().int().min(0).default(0),
     "enforce-unique-senders-per-bundle": z.boolean().default(true),
-    "max-gas-per-user-op": z.string().transform(BigInt).default("20000000"),
+    "max-gas-per-user-op": z.string().transform(BigInt).default("10000000"),
     "max-gas-per-bundle": z.string().transform(BigInt).default("20000000"),
     "rpc-methods": z
         .string()

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -134,7 +134,7 @@ export const bundlerOptions: CliCommandOptions<IBundlerArgsInput> = {
         description: "Maximum amount of gas per bundle",
         type: "string",
         require: false,
-        default: "20000000"
+        default: "16000000"
     },
     "rpc-methods": {
         description: "Supported RPC methods split by commas",

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -128,7 +128,7 @@ export const bundlerOptions: CliCommandOptions<IBundlerArgsInput> = {
         description: "Maximum amount of gas per user operation",
         type: "string",
         require: false,
-        default: "20000000"
+        default: "10000000"
     },
     "max-gas-per-bundle": {
         description: "Maximum amount of gas per bundle",


### PR DESCRIPTION
- Reduce the default max gas per user operation

- Keep CLI schema and option defaults aligned
