### PR TITLE
fix: correct broken docs link in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://docs.pimlico/reference/bundler"><img width="1000" title="Alto" src='https://i.imgur.com/qgVAdjN.png' /></a></p>
+<p align="center"><a href="https://docs.pimlico.io/reference/bundler"><img width="1000" title="Alto" src='https://i.imgur.com/qgVAdjN.png' /></a></p>
 
 # ⛰️ Alto ⛰️
 


### PR DESCRIPTION
### What
Fix the header link `https://docs.pimlico/reference/bundler` → `https://docs.pimlico.io/reference/bundler` (missing `.io` TLD).

### Why
The link at the top of the README points to `docs.pimlico` which is not a valid domain — it should be `docs.pimlico.io`, consistent with every other docs link used throughout the file.

Small, scoped fix from kcolbchain contrib-bot.