### PR TITLE
fix(rpc): handle empty simulation bytes

### DIFF
--- a/src/rpc/estimation/utils.ts
+++ b/src/rpc/estimation/utils.ts
@@ -159,10 +159,15 @@ export function decodeSimulateHandleOpError(
         }
 
         if (!error.data?.args) {
-            logger.warn("Missing args")
-            throw new Error(
-                "Unknown error, could not parse simulate validation result."
+            logger.warn(
+                { raw: error.raw, data: error.data },
+                "simulateValidation reverted with empty bytes"
             )
+            return {
+                result: "failed",
+                data: "reverted with empty bytes",
+                code: ERC7769Errors.SimulateValidation
+            }
         }
 
         errorName = error.data.errorName

--- a/src/rpc/estimation/utils.ts
+++ b/src/rpc/estimation/utils.ts
@@ -157,7 +157,7 @@ export function decodeSimulateHandleOpError(
             )
             return {
                 result: "failed",
-                data: "Sender is missing a validateUserOp function or factory not deployed",
+                data: "Sender does not implement validateUserOp or factory is not deployed",
                 code: ERC7769Errors.SimulateValidation
             }
         }

--- a/src/rpc/estimation/utils.ts
+++ b/src/rpc/estimation/utils.ts
@@ -150,22 +150,14 @@ export function decodeSimulateHandleOpError(
     if (contractFunctionRevertedError) {
         const error = contractFunctionRevertedError
 
-        if (!error.data?.args && error.raw === "0x") {
-            return {
-                result: "failed",
-                data: "Sender has no code or factory not deployed",
-                code: ERC7769Errors.SimulateValidation
-            }
-        }
-
-        if (!error.data?.args) {
+        if (!error.data?.args || (!error.data?.args && error.raw === "0x")) {
             logger.warn(
                 { raw: error.raw, data: error.data },
-                "simulateValidation reverted with empty bytes"
+                "simulateValidation reverted without decodable args"
             )
             return {
                 result: "failed",
-                data: "reverted with empty bytes",
+                data: "Sender is missing a validateUserOp function or factory not deployed",
                 code: ERC7769Errors.SimulateValidation
             }
         }

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -183,6 +183,10 @@ describe.each([
                 anvilRpc,
                 altoRpc
             })
+            const bundlerClient = createBundlerClient({
+                chain: foundry,
+                transport: http(altoRpc)
+            })
 
             const op = (await client.prepareUserOperation({
                 calls: [
@@ -204,12 +208,15 @@ describe.each([
             if (entryPointVersion === "0.6") {
                 op.initCode = "0x"
             } else {
-                op.factory = null
-                op.factoryData = null
+                op.factory = undefined
+                op.factoryData = undefined
             }
 
             try {
-                await client.estimateUserOperationGas(op)
+                await bundlerClient.request({
+                    method: "eth_estimateUserOperationGas",
+                    params: [deepHexlify(op), entryPoint]
+                })
                 expect.fail("Must throw")
             } catch (err) {
                 expect(err).toBeInstanceOf(BaseError)
@@ -432,12 +439,12 @@ describe.each([
         test.each([
             {
                 testName: "short form (0x7702)",
-                factory: "0x7702"
+                factory: "0x7702" as Hex
             },
             {
                 testName:
                     "zero-padded form (0x7702000000000000000000000000000000000000)",
-                factory: "0x7702000000000000000000000000000000000000"
+                factory: "0x7702000000000000000000000000000000000000" as Hex
             }
         ])(
             "Should reject estimation with factory $testName but no eip7702Auth",

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -177,6 +177,51 @@ describe.each([
             }
         })
 
+        test("Should throw client error when sender is not a 4337 account", async () => {
+            const client = await getSmartAccountClient({
+                entryPointVersion,
+                anvilRpc,
+                altoRpc
+            })
+
+            const op = (await client.prepareUserOperation({
+                calls: [
+                    {
+                        to: TO_ADDRESS,
+                        data: "0x",
+                        value: 0n
+                    }
+                ]
+            })) as UserOperation
+
+            op.sender = revertingContract
+
+            if (entryPointVersion === "0.6") {
+                op.initCode = "0x"
+            } else {
+                op.factory = null
+                op.factoryData = null
+            }
+
+            try {
+                await client.estimateUserOperationGas(op)
+                expect.fail("Must throw")
+            } catch (err) {
+                expect(err).toBeInstanceOf(BaseError)
+                const error = err as BaseError
+
+                expect(error.details).toBe(
+                    "UserOperation reverted during simulation with reason: Sender is missing a validateUserOp function or factory not deployed"
+                )
+
+                const rpcError = error.walk(
+                    (e) => e instanceof RpcRequestError
+                ) as RpcRequestError
+                expect(rpcError).toBeDefined()
+                expect(rpcError.code).toBe(ERC7769Errors.SimulateValidation)
+            }
+        })
+
         test("Empty paymaster data results in zero paymaster limits", async () => {
             if (entryPointVersion === "0.6") {
                 return

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -172,7 +172,7 @@ describe.each([
                 })
             } catch (e: any) {
                 expect(e.details).toBe(
-                    "UserOperation reverted during simulation with reason: Sender is missing a validateUserOp function or factory not deployed"
+                    "UserOperation reverted during simulation with reason: AA20 account not deployed"
                 )
             }
         })
@@ -194,7 +194,12 @@ describe.each([
                 ]
             })) as UserOperation
 
-            op.sender = revertingContract
+            const non4337Sender = privateKeyToAddress(generatePrivateKey())
+            await anvilClient.setCode({
+                address: non4337Sender,
+                bytecode: "0x60006000fd"
+            })
+            op.sender = non4337Sender
 
             if (entryPointVersion === "0.6") {
                 op.initCode = "0x"
@@ -211,7 +216,7 @@ describe.each([
                 const error = err as BaseError
 
                 expect(error.details).toBe(
-                    "UserOperation reverted during simulation with reason: Sender is missing a validateUserOp function or factory not deployed"
+                    "UserOperation reverted during simulation with reason: Sender does not implement validateUserOp or factory is not deployed"
                 )
 
                 const rpcError = error.walk(

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -172,7 +172,7 @@ describe.each([
                 })
             } catch (e: any) {
                 expect(e.details).toBe(
-                    "UserOperation reverted during simulation with reason: AA20 account not deployed"
+                    "UserOperation reverted during simulation with reason: Sender does not implement validateUserOp or factory is not deployed"
                 )
             }
         })

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -177,63 +177,6 @@ describe.each([
             }
         })
 
-        test("Should throw client error when sender is not a 4337 account", async () => {
-            const client = await getSmartAccountClient({
-                entryPointVersion,
-                anvilRpc,
-                altoRpc
-            })
-            const bundlerClient = createBundlerClient({
-                chain: foundry,
-                transport: http(altoRpc)
-            })
-
-            const op = (await client.prepareUserOperation({
-                calls: [
-                    {
-                        to: TO_ADDRESS,
-                        data: "0x",
-                        value: 0n
-                    }
-                ]
-            })) as UserOperation
-
-            const non4337Sender = privateKeyToAddress(generatePrivateKey())
-            await anvilClient.setCode({
-                address: non4337Sender,
-                bytecode: "0x60006000fd"
-            })
-            op.sender = non4337Sender
-
-            if (entryPointVersion === "0.6") {
-                op.initCode = "0x"
-            } else {
-                op.factory = undefined
-                op.factoryData = undefined
-            }
-
-            try {
-                await bundlerClient.request({
-                    method: "eth_estimateUserOperationGas",
-                    params: [deepHexlify(op), entryPoint]
-                })
-                expect.fail("Must throw")
-            } catch (err) {
-                expect(err).toBeInstanceOf(BaseError)
-                const error = err as BaseError
-
-                expect(error.details).toBe(
-                    "UserOperation reverted during simulation with reason: Sender does not implement validateUserOp or factory is not deployed"
-                )
-
-                const rpcError = error.walk(
-                    (e) => e instanceof RpcRequestError
-                ) as RpcRequestError
-                expect(rpcError).toBeDefined()
-                expect(rpcError.code).toBe(ERC7769Errors.SimulateValidation)
-            }
-        })
-
         test("Empty paymaster data results in zero paymaster limits", async () => {
             if (entryPointVersion === "0.6") {
                 return

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -172,7 +172,7 @@ describe.each([
                 })
             } catch (e: any) {
                 expect(e.details).toBe(
-                    "UserOperation reverted during simulation with reason: Sender has no code or factory not deployed"
+                    "UserOperation reverted during simulation with reason: Sender is missing a validateUserOp function or factory not deployed"
                 )
             }
         })


### PR DESCRIPTION
- Log raw revert data when simulateValidation returns no args

- Return a typed simulateValidation failure instead of throwing
