### PR TITLE
feat(cli): broadcast tx rpc urls

### DIFF
--- a/src/cli/broadcastTransport.ts
+++ b/src/cli/broadcastTransport.ts
@@ -1,0 +1,70 @@
+import type { Logger } from "@alto/utils"
+import {
+    BaseError,
+    type EIP1193RequestFn,
+    type HttpTransportConfig,
+    RpcRequestError,
+    type Transport,
+    createTransport
+} from "viem"
+import { customTransport } from "./customTransport"
+
+// Broadcasts eth_sendRawTransaction to all endpoints in parallel, resolving
+// with the first successful response. Individual endpoint failures are
+// swallowed unless every endpoint fails. All other methods fall through the
+// endpoints sequentially.
+export function broadcastTransport(
+    urls: string[],
+    config: HttpTransportConfig & { logger: Logger }
+): Transport {
+    return (opts) => {
+        const transports = urls.map((url) =>
+            customTransport(url, {
+                ...config,
+                logger: config.logger.child({ url })
+            })({ ...opts, retryCount: 0 })
+        )
+
+        return createTransport({
+            key: "broadcast",
+            name: "Broadcast JSON-RPC",
+            type: "broadcast",
+            retryCount: config.retryCount ?? opts.retryCount,
+            retryDelay: config.retryDelay,
+            timeout: config.timeout ?? opts.timeout,
+            request: (async ({ method, params }) => {
+                if (method !== "eth_sendRawTransaction") {
+                    let lastError: unknown
+                    for (const transport of transports) {
+                        try {
+                            return await transport.request({ method, params })
+                        } catch (err) {
+                            lastError = err
+                        }
+                    }
+                    throw lastError
+                }
+
+                try {
+                    return await Promise.any(
+                        transports.map((transport) =>
+                            transport.request({ method, params })
+                        )
+                    )
+                } catch (err) {
+                    const { errors } = err as AggregateError
+                    // Prefer an error the node actually responded with over
+                    // a network-level failure so downstream classification
+                    // (underpriced, fee too low, ...) keeps working.
+                    const rpcError = errors.find(
+                        (e) =>
+                            e instanceof BaseError &&
+                            e.walk((c) => c instanceof RpcRequestError) !==
+                                null
+                    )
+                    throw rpcError ?? errors[0]
+                }
+            }) as EIP1193RequestFn
+        })
+    }
+}

--- a/src/cli/broadcastTransport.ts
+++ b/src/cli/broadcastTransport.ts
@@ -59,8 +59,7 @@ export function broadcastTransport(
                     const rpcError = errors.find(
                         (e) =>
                             e instanceof BaseError &&
-                            e.walk((c) => c instanceof RpcRequestError) !==
-                                null
+                            e.walk((c) => c instanceof RpcRequestError) !== null
                     )
                     throw rpcError ?? errors[0]
                 }

--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -224,7 +224,11 @@ export const serverArgsSchema = z.object({
 
 export const rpcArgsSchema = z.object({
     "rpc-url": z.string().url(),
-    "send-transaction-rpc-url": z.string().url().optional(),
+    "send-transaction-rpc-url": z
+        .string()
+        .transform((val) => val.split(",").map((url) => url.trim()))
+        .pipe(z.array(z.string().url()).min(1))
+        .optional(),
     "block-time": z.number().int().min(0),
     "block-polling-interval": z.number().int().min(0).optional(),
     "max-block-wait-count": z.number().int().min(0).optional().default(2),

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -708,7 +708,8 @@ export const rpcOptions: CliCommandOptions<IRpcArgsInput> = {
         require: true
     },
     "send-transaction-rpc-url": {
-        description: "RPC url to send transactions to (e.g. flashbots relay)",
+        description:
+            "Comma separated list of RPC urls to send transactions to (e.g. flashbots relay). Transactions are broadcast to all urls in parallel",
         type: "string",
         require: false
     },

--- a/src/cli/handler.ts
+++ b/src/cli/handler.ts
@@ -17,6 +17,7 @@ import {
 import * as chains from "viem/chains"
 import { type AltoConfig, createConfig } from "../createConfig"
 import { getSenderManager } from "../executor/senderManager/index"
+import { broadcastTransport } from "./broadcastTransport"
 import type { IOptionsInput } from "./config"
 import { customTransport } from "./customTransport"
 import { deploySimulationsContract } from "./deploySimulationsContract"
@@ -189,12 +190,14 @@ export async function bundlerHandler(args_: IOptionsInput): Promise<void> {
             .extend(withEthCallSender)
     }
 
+    const walletClientLogger = logger.child(
+        { module: "wallet_client" },
+        { level: args.walletClientLogLevel || args.logLevel }
+    )
+
     const createWalletTransport = (url: string) =>
         customTransport(url, {
-            logger: logger.child(
-                { module: "wallet_client" },
-                { level: args.walletClientLogLevel || args.logLevel }
-            )
+            logger: walletClientLogger
         })
 
     const walletClients = {
@@ -202,7 +205,9 @@ export async function bundlerHandler(args_: IOptionsInput): Promise<void> {
             ? createWalletClient({
                   transport: fallback(
                       [
-                          createWalletTransport(args.sendTransactionRpcUrl),
+                          broadcastTransport(args.sendTransactionRpcUrl, {
+                              logger: walletClientLogger
+                          }),
                           createWalletTransport(args.rpcUrl)
                       ],
                       { rank: false }


### PR DESCRIPTION
- allow multiple send-transaction rpc urls in cli config

- add broadcast transport to send raw transactions in parallel

- reuse wallet client logger for broadcast endpoint logging
