### PR TITLE
fix(executor): only expose wallet gauges from refill lock winner

### DIFF
--- a/src/executor/senderManager/validateAndRefill.ts
+++ b/src/executor/senderManager/validateAndRefill.ts
@@ -151,8 +151,9 @@ export const validateAndRefillWallets = async ({
         return
     }
 
-    // With horizontal scaling, use a Redis SET NX lock so only one instance
-    // performs the balance check/refill per interval. Fail-open on Redis errors.
+    // With horizontal scaling, a Redis SET NX lock ensures only one instance
+    // refills per interval. Non-winners remove their wallet gauge samples so
+    // only the latest winner exposes values.
     if (config.enableHorizontalScaling && config.redisEndpoint) {
         if (!redisClient) {
             redisClient = new Redis(config.redisEndpoint)
@@ -175,6 +176,10 @@ export const validateAndRefillWallets = async ({
             })
 
         if (acquired !== "OK") {
+            metrics.utilityWalletBalance.remove()
+            metrics.utilityWalletInsufficientBalance.remove()
+            metrics.utilityWalletMissingBalance.remove()
+            metrics.executorWalletsBalances.reset()
             return
         }
     }

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -194,6 +194,11 @@ export function createMetrics(registry: Registry, register = true) {
         registers
     })
 
+    // Gauges default to 0, we remove the default value here.
+    utilityWalletBalance.remove()
+    utilityWalletInsufficientBalance.remove()
+    utilityWalletMissingBalance.remove()
+
     const executorWalletsBalances = new Gauge({
         name: "alto_executor_wallet_balance",
         help: "Balance of the executor wallet",


### PR DESCRIPTION
## Problem

With horizontal scaling, every instance exposes process-local utility-wallet gauges, but only the Redis-lock-winning instance updates them each refill cycle. Non-winning instances report either prom-client's seeded `0` (unlabelled gauges start at 0) or a stale value from an earlier winning cycle, so chain-level aggregations of `alto_utility_wallet_*` can't be trusted.

## Fix — winner-only exposes

- `createMetrics` removes the seeded zero samples of `alto_utility_wallet_balance`, `alto_utility_wallet_insufficient_balance`, and `alto_utility_wallet_missing_balance` at construction, so "never observed" is series **absence**, never a healthy-looking 0.
- Instances that lose the refill lock remove their samples (`gauge.remove()`) and reset the per-wallet balance gauge before returning, instead of returning silently. Only the latest lock winner exposes wallet state.
- Redis lock errors still fail open (proceed with the refill) so executors keep getting refilled through Redis outages, at the cost of possible duplicate refills.
- Winner path and non-horizontal-scaling deployments are unchanged (gauges reappear on first `set()`).

Verified in prom-client 14.2.0: zero-arg `gauge.remove()` truly deletes an unlabelled gauge's sample (registry emits HELP/TYPE only), whereas `reset()` re-seeds it to 0.

## Trade-offs

- After a state change, a former winner's outdated value can linger up to ~one refill interval until its next cycle removes or refreshes it.
- If no instance holds a recent observation (e.g. winner terminated mid-interval), the series is absent rather than stale — consumers should treat absence as unknown.

## Testing

- `pnpm build` and `pnpm lint` pass.
- Ran the built `createMetrics` through the lifecycle: no samples at construction → exposed after `set()` → absent after `remove()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

