### PR TITLE
fix(sender-manager): avoid empty batch refills

### DIFF
--- a/src/executor/senderManager/validateAndRefill.ts
+++ b/src/executor/senderManager/validateAndRefill.ts
@@ -313,7 +313,7 @@ export const validateAndRefillWallets = async ({
             refillAmount: scaleBigIntByPercent(minBalance, 120n) - balance
         }))
 
-    if (await canBatchRefills(config)) {
+    if (refills.length > 0 && (await canBatchRefills(config))) {
         try {
             await sendBatchRefillTransaction({
                 config,


### PR DESCRIPTION
- Skip batch refill submission when no wallets need refilling

- Preserve existing batch refill flow for real refill requests
