### PR TITLE
feat(cli): add multi rpc sending

### DIFF
--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -227,7 +227,11 @@ export const serverArgsSchema = z.object({
 
 export const rpcArgsSchema = z.object({
     "rpc-url": z.string().url(),
-    "send-transaction-rpc-url": z.string().url().optional(),
+    "send-transaction-rpc-url": z
+        .string()
+        .optional()
+        .transform((val) => val?.split(","))
+        .pipe(z.array(z.string().url()).optional()),
     "block-time": z.number().int().min(0),
     "block-polling-interval": z.number().int().min(0).optional(),
     "max-block-wait-count": z.number().int().min(0).optional().default(2),

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -715,7 +715,8 @@ export const rpcOptions: CliCommandOptions<IRpcArgsInput> = {
         require: true
     },
     "send-transaction-rpc-url": {
-        description: "RPC url to send transactions to (e.g. flashbots relay)",
+        description:
+            "Comma separated list of RPC urls to send transactions to (e.g. sequencer + private relay). Transactions are sent to all endpoints in parallel",
         type: "string",
         require: false
     },

--- a/src/cli/handler.ts
+++ b/src/cli/handler.ts
@@ -204,6 +204,7 @@ export async function bundlerHandler(args_: IOptionsInput): Promise<void> {
                   transport: fallback(
                       [
                           multiRpcTransport(args.sendTransactionRpcUrl, {
+                              chainId,
                               logger: logger.child(
                                   { module: "wallet_client" },
                                   {

--- a/src/cli/handler.ts
+++ b/src/cli/handler.ts
@@ -20,6 +20,7 @@ import { getSenderManager } from "../executor/senderManager/index"
 import type { IOptionsInput } from "./config"
 import { customTransport } from "./customTransport"
 import { deploySimulationsContract } from "./deploySimulationsContract"
+import { multiRpcTransport } from "./multiRpcTransport"
 import { parseArgs } from "./parseArgs"
 import { setupServer } from "./setupServer"
 
@@ -202,7 +203,16 @@ export async function bundlerHandler(args_: IOptionsInput): Promise<void> {
             ? createWalletClient({
                   transport: fallback(
                       [
-                          createWalletTransport(args.sendTransactionRpcUrl),
+                          multiRpcTransport(args.sendTransactionRpcUrl, {
+                              logger: logger.child(
+                                  { module: "wallet_client" },
+                                  {
+                                      level:
+                                          args.walletClientLogLevel ||
+                                          args.logLevel
+                                  }
+                              )
+                          }),
                           createWalletTransport(args.rpcUrl)
                       ],
                       { rank: false }

--- a/src/cli/multiRpcTransport.ts
+++ b/src/cli/multiRpcTransport.ts
@@ -1,0 +1,72 @@
+import type { Logger } from "@alto/utils"
+import {
+    type EIP1193RequestFn,
+    type HttpTransportConfig,
+    type Transport,
+    createTransport
+} from "viem"
+import { customTransport } from "./customTransport"
+
+// Fans out eth_sendRawTransaction to all urls in parallel, resolving with the
+// first successful response and rejecting only if every endpoint fails. All
+// other methods are routed to the first url.
+export function multiRpcTransport(
+    urls: string[],
+    config: HttpTransportConfig & { logger: Logger }
+): Transport {
+    const { key = "multiRpc", name = "Multi RPC JSON-RPC", logger } = config
+
+    return ({ chain, retryCount, timeout }) => {
+        const transports = urls.map((url) =>
+            customTransport(url, {
+                ...config,
+                logger: logger.child({ sendTransactionRpcUrl: url })
+            })({ chain, retryCount: 0, timeout })
+        )
+
+        return createTransport({
+            key,
+            name,
+            request: (async ({
+                method,
+                params
+            }: {
+                method: string
+                params?: unknown
+            }) => {
+                if (method !== "eth_sendRawTransaction") {
+                    return await transports[0].request({ method, params })
+                }
+
+                const sends = transports.map((transport, index) => {
+                    const send = transport.request({ method, params })
+                    // Handle every rejection eagerly so an endpoint failing
+                    // after another already succeeded can never become an
+                    // unhandled rejection.
+                    send.catch((err: unknown) => {
+                        logger.warn(
+                            { err, url: urls[index] },
+                            "send transaction endpoint failed"
+                        )
+                    })
+                    return send
+                })
+
+                try {
+                    return await Promise.any(sends)
+                } catch (err) {
+                    // Rethrow the first endpoint's error instead of the
+                    // AggregateError so viem's error classification (nonce
+                    // too low, underpriced, ...) keeps working.
+                    if (err instanceof AggregateError) {
+                        throw err.errors[0]
+                    }
+                    throw err
+                }
+            }) as EIP1193RequestFn,
+            retryCount: config.retryCount ?? retryCount,
+            timeout,
+            type: "http"
+        })
+    }
+}

--- a/src/cli/multiRpcTransport.ts
+++ b/src/cli/multiRpcTransport.ts
@@ -3,18 +3,27 @@ import {
     type EIP1193RequestFn,
     type HttpTransportConfig,
     type Transport,
-    createTransport
+    createTransport,
+    numberToHex
 } from "viem"
 import { customTransport } from "./customTransport"
 
-// Fans out eth_sendRawTransaction to all urls in parallel, resolving with the
-// first successful response and rejecting only if every endpoint fails. All
-// other methods are routed to the first url.
+// Fans out every request to all urls in parallel, resolving with the first
+// successful response and rejecting only if every endpoint fails. Fanning out
+// non-send methods too keeps a lagging or method-restricted endpoint (e.g. a
+// sequencer that only accepts eth_sendRawTransaction) from stalling requests.
+// eth_chainId is answered locally: viem calls it before every sendTransaction
+// and some endpoints don't allow it.
 export function multiRpcTransport(
     urls: string[],
-    config: HttpTransportConfig & { logger: Logger }
+    config: HttpTransportConfig & { logger: Logger; chainId: number }
 ): Transport {
-    const { key = "multiRpc", name = "Multi RPC JSON-RPC", logger } = config
+    const {
+        key = "multiRpc",
+        name = "Multi RPC JSON-RPC",
+        logger,
+        chainId
+    } = config
 
     return ({ chain, retryCount, timeout }) => {
         const transports = urls.map((url) =>
@@ -34,8 +43,8 @@ export function multiRpcTransport(
                 method: string
                 params?: unknown
             }) => {
-                if (method !== "eth_sendRawTransaction") {
-                    return await transports[0].request({ method, params })
+                if (method === "eth_chainId") {
+                    return numberToHex(chainId)
                 }
 
                 const sends = transports.map((transport, index) => {
@@ -45,8 +54,8 @@ export function multiRpcTransport(
                     // unhandled rejection.
                     send.catch((err: unknown) => {
                         logger.warn(
-                            { err, url: urls[index] },
-                            "send transaction endpoint failed"
+                            { err, url: urls[index], method },
+                            "multi rpc endpoint request failed"
                         )
                     })
                     return send

--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -242,6 +242,9 @@ export class Executor {
             data: handleOpsCalldata,
             from: account.address,
             chain: publicClient.chain,
+            // Providing chainId lets viem skip its eth_fillTransaction and
+            // eth_chainId round-trips before eth_sendRawTransaction.
+            chainId: this.config.chainId,
             gas,
             account,
             nonce,


### PR DESCRIPTION
- allow configuring multiple send-transaction rpc urls

- fan out raw transaction sends across all endpoints in parallel

- preserve viem error handling by surfacing the first failure
