### PR TITLE
fix(executor): make the wallet-refill lock hold for the interval and fail closed

### DIFF
--- a/src/executor/senderManager/validateAndRefill.ts
+++ b/src/executor/senderManager/validateAndRefill.ts
@@ -299,20 +299,28 @@ export const validateAndRefillWallets = async ({
             redisClient = new Redis(config.redisEndpoint)
         }
 
+        // TTL must cover most of the refill interval: at half the interval a
+        // second instance ticking later in the same interval can acquire the
+        // lock and refill twice per interval.
         const acquired = await redisClient
             .set(
                 `${config.redisKeyPrefix}:${config.chainId}:wallet-refill-lock`,
                 "1",
                 "EX",
-                Math.floor(config.executorRefillInterval / 2),
+                Math.max(1, Math.floor(config.executorRefillInterval * 0.9)),
                 "NX"
             )
             .catch((err: unknown) => {
+                // The lock exists to prevent duplicate fund movements. If we
+                // cannot verify exclusivity, skip this interval instead of
+                // refilling concurrently on every scaled instance. Wallets
+                // still hold their remaining balance, so a skipped interval
+                // is recoverable; duplicated refills are not free.
                 logger.warn(
                     { err },
-                    "Redis lock check failed, proceeding with update"
+                    "Redis lock check failed, skipping refill this interval"
                 )
-                return "OK"
+                return null
             })
 
         if (acquired !== "OK") {


### PR DESCRIPTION
## Summary

With `enableHorizontalScaling`, the Redis `SET NX` lock is documented to "ensure only one instance refills per interval". Two defects defeat that:

1. **TTL is half the refill interval.** An instance ticking in the second half of the interval acquires the expired lock and refills again, so a single interval can produce two rounds of refills even with Redis healthy.
2. **The lock fails open on Redis error.** If the `SET` throws, the `.catch` returns `"OK"`, which the code treats as lock acquired. Every scaled instance then proceeds to plan and send refill transactions concurrently. Each instance plans from pre-refill balances, so wallets can be topped up N times (once per instance), moving up to N times the intended funds out of the utility wallet in one interval.

## Fix

- Lock TTL is now 90% of `executorRefillInterval`: long enough to cover the interval, short enough to release before the next scheduled tick.
- On lock-check error, skip the refill for this interval (fail closed). Rationale: the lock's purpose is to prevent duplicate fund movements; proceeding when exclusivity cannot be verified is the unsafe direction. Wallets still hold their remaining balance, so a skipped interval self-recovers on the next tick, while duplicated refills are not free. The warn log now says what happened.

## Test plan

- [x] `tsc --noEmit` clean for the changed file (repo-wide run has pre-existing missing forge-artifact errors unrelated to this change)
- [x] `biome check` clean (only pre-existing warnings, verified identical with the change stashed)

Made with [Cursor](https://cursor.com)