### PR TITLE
fix(executor): reserve refill gas in planRefills instead of planning against the full utility balance

### DIFF
--- a/src/executor/senderManager/validateAndRefill.ts
+++ b/src/executor/senderManager/validateAndRefill.ts
@@ -34,11 +34,13 @@ type RefillPlan = {
 const planRefills = ({
     balances,
     minBalance,
-    utilityBalance
+    utilityBalance,
+    maxFeePerGas
 }: {
     balances: { address: Address; balance: bigint }[]
     minBalance: bigint
     utilityBalance: bigint
+    maxFeePerGas: bigint
 }): RefillPlan => {
     // Top up wallets below minBalance to 120% of minBalance
     const candidates: Refill[] = balances
@@ -49,12 +51,16 @@ const planRefills = ({
             refillAmount: scaleBigIntByPercent(minBalance, 120n) - balance
         }))
 
+    // Reserve the refills' own gas: every refill spends from the same utility
+    // account that pays for the transactions, so planning against the full
+    // balance guarantees out-of-gas reverts once the wallet runs low.
+    const gasPerRefill = 21_000n * maxFeePerGas
     const refills: Refill[] = []
     let total = 0n
     for (const candidate of candidates) {
-        if (total + candidate.refillAmount <= utilityBalance) {
+        if (total + candidate.refillAmount + gasPerRefill <= utilityBalance) {
             refills.push(candidate)
-            total += candidate.refillAmount
+            total += candidate.refillAmount + gasPerRefill
         }
     }
 
@@ -356,7 +362,8 @@ export const validateAndRefillWallets = async ({
     const { refills, insufficientBalance } = planRefills({
         balances,
         minBalance,
-        utilityBalance
+        utilityBalance,
+        maxFeePerGas
     })
 
     if (insufficientBalance) {


### PR DESCRIPTION
## Problem

`validateAndRefill` fetches a (200%-bumped) gas price and the utility wallet balance, but `planRefills` only compares refill amounts against the **raw balance**. The refill transactions' own gas is paid from that same utility account, so when the wallet runs low:

1. The plan commits refills totaling ≈ 100% of the balance.
2. The refill transaction(s) revert with insufficient funds (value + gas > balance).
3. Each failed attempt burns more of the balance it was trying to distribute — the wallet self-drains through reverts while the executors stay underfunded.

## Fix

`planRefills` takes the already-fetched `maxFeePerGas` and reserves `21000 * maxFeePerGas` per refill before committing it. Refills that no longer fit (value + their gas) are skipped, degrading to the existing partial-refill path instead of guaranteed reverts.

## Testing

- `tsc --noEmit` on `src/`: no new diagnostics (the 11 pre-existing contract-artifact errors on a fresh clone are unchanged with and without this patch).

Made with Cursor

Made with [Cursor](https://cursor.com)