### PR TITLE
fix(rpc): gate zero-fee boost sponsorship behind --enable-boost-endpoint

### DIFF
--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -106,6 +106,7 @@ export const bundlerArgsSchema = z.object({
             )}`
         ),
     "enable-instant-bundling-endpoint": z.boolean(),
+    "enable-boost-endpoint": z.boolean(),
     "skip-local-gas-calculations": z.boolean(),
     "flashblocks-preconfirmation-time": z.number().optional(),
     "receipt-cache-ttl": z.number().int().min(0).optional().default(60000) // Default to 1 minute

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -148,6 +148,12 @@ export const bundlerOptions: CliCommandOptions<IBundlerArgsInput> = {
         type: "boolean",
         default: false
     },
+    "enable-boost-endpoint": {
+        description:
+            "Should the bundler accept zero-fee boosted UserOperations (boost_sendUserOperation and eth_sendUserOperation with maxFeePerGas=maxPriorityFeePerGas=0). Default false: zero-fee ops are free gas sponsorship paid by the executor wallets.",
+        type: "boolean",
+        default: false
+    },
     "skip-local-gas-calculations": {
         description:
             "Skip break-even gas price calculation and use network gas price only. Enable on chains where eth_estimateGas must be called.",

--- a/src/rpc/methods/boost_sendUserOperation.ts
+++ b/src/rpc/methods/boost_sendUserOperation.ts
@@ -1,4 +1,4 @@
-import { RpcError } from "@alto/types"
+import { ERC7769Errors, RpcError } from "@alto/types"
 import { isVersion06, isVersion07 } from "@alto/utils"
 import {
     type UserOperation,
@@ -40,6 +40,13 @@ export const boostSendUserOperationHandler = createMethodHandler({
     method: "boost_sendUserOperation",
     schema: boostSendUserOperationSchema,
     handler: async ({ rpcHandler, params, apiVersion }) => {
+        if (!rpcHandler.config.enableBoostEndpoint) {
+            throw new RpcError(
+                "boost_sendUserOperation endpoint is not enabled",
+                ERC7769Errors.InvalidFields
+            )
+        }
+
         const [userOp, entryPoint] = params
 
         validateUserOp({ userOp })

--- a/src/rpc/rpcHandler.ts
+++ b/src/rpc/rpcHandler.ts
@@ -241,7 +241,21 @@ export class RpcHandler {
         apiVersion: ApiVersion
         isBoosted?: boolean
     }): Promise<[boolean, string]> {
-        if (apiVersion === "v1" || this.config.safeMode || isBoosted) {
+        // Zero fees mean the bundler sponsors inclusion gas with no on-chain
+        // reimbursement. That is only safe when the operator opted into boost.
+        const isZeroFee =
+            userOp.maxFeePerGas === 0n && userOp.maxPriorityFeePerGas === 0n
+        if (isZeroFee || isBoosted) {
+            if (!this.config.enableBoostEndpoint) {
+                return [
+                    false,
+                    "zero-fee (boosted) UserOperations require --enable-boost-endpoint"
+                ]
+            }
+            return [true, ""]
+        }
+
+        if (apiVersion === "v1" || this.config.safeMode) {
             return [true, ""]
         }
 

--- a/test/e2e/alto-config.json
+++ b/test/e2e/alto-config.json
@@ -19,5 +19,6 @@
     "enforce-unique-senders-per-bundle": false,
     "code-override-support": true,
     "enable-instant-bundling-endpoint": true,
+    "enable-boost-endpoint": true,
     "bundling-mode": "manual"
 }


### PR DESCRIPTION
## Summary

`boost_sendUserOperation` (and `eth_sendUserOperation` with `maxFeePerGas = maxPriorityFeePerGas = 0`) makes the bundler pay inclusion gas with **no on-chain reimbursement**. That is intentional for Pimlico-style boosted sponsorship, but in OSS Alto the method was always registered with no opt-in flag.

Sibling dangerous endpoints already require explicit enablement (default false):

- `--enable-debug-endpoints`
- `--enable-instant-bundling-endpoint`

Boost did not. Any reachable self-hosted Alto RPC therefore offered free gas sponsorship to anyone who can submit a valid UserOp.

## Fix

1. Add `--enable-boost-endpoint` (default **false**).
2. `boost_sendUserOperation` refuses when the flag is off.
3. `validateUserOpGasPrice` rejects zero-fee ops unless the flag is on (covers the `eth_sendUserOperation` bypass when `safe-mode` skips the gas-price floor).
4. E2E config enables the flag so existing boost tests keep running.

Operators who intentionally sponsor should set `--enable-boost-endpoint` (and keep the RPC behind auth, as with other privileged endpoints).

## Plain language

If someone can talk to your bundler, they could send "boosted" operations that cost you gas money and cost them nothing. This change turns that sponsorship feature off unless you deliberately turn it on.

## Test plan

- [ ] E2E `boost_sendUserOperation` suite green with `enable-boost-endpoint: true` in `test/e2e/alto-config.json`
- [ ] With flag unset/false: `boost_sendUserOperation` returns "endpoint is not enabled"
- [ ] With flag unset/false: `eth_sendUserOperation` with zero fees is rejected
- [ ] Non-zero fee `eth_sendUserOperation` unchanged


Made with [Cursor](https://cursor.com)