### PR TITLE
fix(executor): avoid resending mined bundles

### DIFF
--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -33,7 +33,7 @@ import {
 import type { AltoConfig } from "../createConfig"
 import { filterOpsAndEstimateGas } from "./filterOpsAndEstimateGas"
 import {
-    BundleAlreadyMinedError,
+    ReplacementNonceConflictError,
     encodeHandleOpsCalldata,
     getAuthorizationListFromUserOps,
     getUserOpHashes,
@@ -209,15 +209,15 @@ export class Executor {
         gasOpts,
         childLogger,
         submissionAttempts,
-        replacementTxHashes
+        isReplacement
     }: {
         txParam: HandleOpsTxParams
         gasOpts: HandleOpsGasParams
         childLogger: Logger
         submissionAttempts: number
-        // When set, this send is a replacement of these previous transactions
-        // and must keep the same nonce.
-        replacementTxHashes?: HexData32[]
+        // When set, this send replaces a previous transaction and must keep
+        // the same nonce.
+        isReplacement?: boolean
     }) {
         const {
             sendHandleOpsRetryCount,
@@ -294,7 +294,7 @@ export class Executor {
                         // A replacement must reuse its nonce - refetching here
                         // could pick up a nonce advanced by the transaction
                         // we are replacing and duplicate the bundle.
-                        if (!replacementTxHashes) {
+                        if (!isReplacement) {
                             request.nonce =
                                 await publicClient.getTransactionCount({
                                     address: account.address,
@@ -356,25 +356,13 @@ export class Executor {
                     const cause = error.cause
 
                     if (cause instanceof NonceTooLowError) {
-                        // If one of the bundle's own previous transactions
-                        // consumed the nonce, the bundle already landed
-                        // onchain - resending it would revert with AA25 and
-                        // waste gas. If an unknown transaction consumed it,
-                        // the userOps weren't executed and resending with a
-                        // fresh nonce is safe.
-                        if (replacementTxHashes) {
-                            const minedTxHash = await Promise.any(
-                                replacementTxHashes.map(async (hash) => {
-                                    await publicClient.getTransactionReceipt({
-                                        hash
-                                    })
-                                    return hash
-                                })
-                            ).catch(() => undefined)
-
-                            if (minedTxHash) {
-                                throw new BundleAlreadyMinedError(minedTxHash)
-                            }
+                        // A replacement's nonce was consumed by another
+                        // transaction - resending with a fresh nonce could
+                        // duplicate a bundle that already landed onchain.
+                        // Report the conflict and let the caller resolve who
+                        // consumed the nonce.
+                        if (isReplacement) {
+                            throw new ReplacementNonceConflictError()
                         }
 
                         childLogger.warn("Nonce too low, retrying")
@@ -420,15 +408,15 @@ export class Executor {
         networkGasPrice,
         networkBaseFee,
         nonce,
-        replacementTxHashes
+        isReplacement
     }: {
         executor: Account
         userOpBundle: UserOperationBundle
         networkGasPrice: GasPriceParameters
         networkBaseFee: bigint
         nonce: number
-        // When set, this bundle replaces these previous transactions.
-        replacementTxHashes?: HexData32[]
+        // When set, this bundle replaces a previous transaction.
+        isReplacement?: boolean
     }): Promise<BundleResult> {
         const { entryPoint, userOps } = userOpBundle
 
@@ -530,7 +518,7 @@ export class Executor {
                 childLogger,
                 gasOpts,
                 submissionAttempts: userOpBundle.submissionAttempts,
-                replacementTxHashes
+                isReplacement
             })
 
             this.eventManager.emitSubmitted({
@@ -540,14 +528,15 @@ export class Executor {
         } catch (err: unknown) {
             const { rejectedUserOps, userOpsToBundle } = filterOpsResult
 
-            // The bundle we are replacing already landed onchain, the caller
-            // is responsible for resolving the userOps against the mined tx.
-            if (err instanceof BundleAlreadyMinedError) {
+            // The nonce of the bundle we are replacing was consumed by
+            // another transaction. The caller resolves the userOps against
+            // the mined tx if it was ours, or resubmits them if it wasn't.
+            if (err instanceof ReplacementNonceConflictError) {
                 return {
                     success: false,
-                    reason: "already_mined",
+                    reason: "nonce_conflict",
                     rejectedUserOps,
-                    recoverableOps: []
+                    recoverableOps: userOpsToBundle
                 }
             }
 

--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -33,6 +33,7 @@ import {
 import type { AltoConfig } from "../createConfig"
 import { filterOpsAndEstimateGas } from "./filterOpsAndEstimateGas"
 import {
+    BundleAlreadyMinedError,
     encodeHandleOpsCalldata,
     getAuthorizationListFromUserOps,
     getUserOpHashes,
@@ -207,12 +208,16 @@ export class Executor {
         txParam,
         gasOpts,
         childLogger,
-        submissionAttempts
+        submissionAttempts,
+        replacementTxHashes
     }: {
         txParam: HandleOpsTxParams
         gasOpts: HandleOpsGasParams
         childLogger: Logger
         submissionAttempts: number
+        // When set, this send is a replacement of these previous transactions
+        // and must keep the same nonce.
+        replacementTxHashes?: HexData32[]
     }) {
         const {
             sendHandleOpsRetryCount,
@@ -286,10 +291,16 @@ export class Executor {
                     if (isTransactionUnderpricedError(e)) {
                         childLogger.warn("Transaction underpriced, retrying")
 
-                        request.nonce = await publicClient.getTransactionCount({
-                            address: account.address,
-                            blockTag: "latest"
-                        })
+                        // A replacement must reuse its nonce - refetching here
+                        // could pick up a nonce advanced by the transaction
+                        // we are replacing and duplicate the bundle.
+                        if (!replacementTxHashes) {
+                            request.nonce =
+                                await publicClient.getTransactionCount({
+                                    address: account.address,
+                                    blockTag: "latest"
+                                })
+                        }
 
                         if (request.maxFeePerGas) {
                             request.maxFeePerGas = scaleBigIntByPercent(
@@ -345,6 +356,27 @@ export class Executor {
                     const cause = error.cause
 
                     if (cause instanceof NonceTooLowError) {
+                        // If one of the bundle's own previous transactions
+                        // consumed the nonce, the bundle already landed
+                        // onchain - resending it would revert with AA25 and
+                        // waste gas. If an unknown transaction consumed it,
+                        // the userOps weren't executed and resending with a
+                        // fresh nonce is safe.
+                        if (replacementTxHashes) {
+                            const minedTxHash = await Promise.any(
+                                replacementTxHashes.map(async (hash) => {
+                                    await publicClient.getTransactionReceipt({
+                                        hash
+                                    })
+                                    return hash
+                                })
+                            ).catch(() => undefined)
+
+                            if (minedTxHash) {
+                                throw new BundleAlreadyMinedError(minedTxHash)
+                            }
+                        }
+
                         childLogger.warn("Nonce too low, retrying")
                         request.nonce = await publicClient.getTransactionCount({
                             address: request.from,
@@ -387,13 +419,16 @@ export class Executor {
         userOpBundle,
         networkGasPrice,
         networkBaseFee,
-        nonce
+        nonce,
+        replacementTxHashes
     }: {
         executor: Account
         userOpBundle: UserOperationBundle
         networkGasPrice: GasPriceParameters
         networkBaseFee: bigint
         nonce: number
+        // When set, this bundle replaces these previous transactions.
+        replacementTxHashes?: HexData32[]
     }): Promise<BundleResult> {
         const { entryPoint, userOps } = userOpBundle
 
@@ -494,7 +529,8 @@ export class Executor {
                 },
                 childLogger,
                 gasOpts,
-                submissionAttempts: userOpBundle.submissionAttempts
+                submissionAttempts: userOpBundle.submissionAttempts,
+                replacementTxHashes
             })
 
             this.eventManager.emitSubmitted({
@@ -503,6 +539,17 @@ export class Executor {
             })
         } catch (err: unknown) {
             const { rejectedUserOps, userOpsToBundle } = filterOpsResult
+
+            // The bundle we are replacing already landed onchain, the caller
+            // is responsible for resolving the userOps against the mined tx.
+            if (err instanceof BundleAlreadyMinedError) {
+                return {
+                    success: false,
+                    reason: "already_mined",
+                    rejectedUserOps,
+                    recoverableOps: []
+                }
+            }
 
             const isViemExecutionError =
                 err instanceof ContractFunctionExecutionError ||

--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -291,16 +291,10 @@ export class Executor {
                     if (isTransactionUnderpricedError(e)) {
                         childLogger.warn("Transaction underpriced, retrying")
 
-                        // A replacement must reuse its nonce - refetching here
-                        // could pick up a nonce advanced by the transaction
-                        // we are replacing and duplicate the bundle.
-                        if (!isReplacement) {
-                            request.nonce =
-                                await publicClient.getTransactionCount({
-                                    address: account.address,
-                                    blockTag: "latest"
-                                })
-                        }
+                        request.nonce = await publicClient.getTransactionCount({
+                            address: account.address,
+                            blockTag: "latest"
+                        })
 
                         if (request.maxFeePerGas) {
                             request.maxFeePerGas = scaleBigIntByPercent(

--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -678,8 +678,36 @@ export class ExecutorManager {
             networkGasPrice,
             networkBaseFee,
             userOpBundle: bundle,
-            nonce: transactionRequest.nonce
+            nonce: transactionRequest.nonce,
+            replacementTxHashes: [
+                submittedBundle.transactionHash,
+                ...submittedBundle.previousTransactionHashes
+            ]
         })
+
+        // The bundle we tried to replace was mined whilst replacing it.
+        // Resume tracking the original bundle so the block watcher resolves
+        // the userOps against the mined transaction (inclusion, reverts,
+        // wallet release) instead of resending and reverting with AA25.
+        if (!bundleResult.success && bundleResult.reason === "already_mined") {
+            this.logger.info(
+                {
+                    oldTxHash,
+                    reason,
+                    userOps: getUserOpHashes(bundle.userOps)
+                },
+                "bundle mined during replacement, skipping replacement"
+            )
+
+            this.bundleManager.trackBundle(submittedBundle)
+            this.startWatchingBlocks()
+
+            this.metrics.replacedTransactions
+                .labels({ reason, status: "already_mined" })
+                .inc()
+
+            return
+        }
 
         // Handle case where no bundle was sent.
         if (!bundleResult.success) {

--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -709,21 +709,23 @@ export class ExecutorManager {
                 this.metrics.replacedTransactions
                     .labels({ reason, status: "already_mined" })
                     .inc()
+            }
 
-                if (bundleStatus.status === "included") {
-                    await this.bundleManager.processIncludedBundle({
-                        submittedBundle,
-                        bundleReceipt: bundleStatus,
-                        blockReceivedTimestamp
-                    })
-                } else {
-                    await this.bundleManager.processRevertedBundle({
-                        submittedBundle,
-                        bundleReceipt: bundleStatus,
-                        blockReceivedTimestamp
-                    })
-                }
+            if (bundleStatus.status === "included") {
+                await this.bundleManager.processIncludedBundle({
+                    submittedBundle,
+                    bundleReceipt: bundleStatus,
+                    blockReceivedTimestamp
+                })
+                return
+            }
 
+            if (bundleStatus.status === "reverted") {
+                await this.bundleManager.processRevertedBundle({
+                    submittedBundle,
+                    bundleReceipt: bundleStatus,
+                    blockReceivedTimestamp
+                })
                 return
             }
 

--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -679,34 +679,58 @@ export class ExecutorManager {
             networkBaseFee,
             userOpBundle: bundle,
             nonce: transactionRequest.nonce,
-            replacementTxHashes: [
-                submittedBundle.transactionHash,
-                ...submittedBundle.previousTransactionHashes
-            ]
+            isReplacement: true
         })
 
-        // The bundle we tried to replace was mined whilst replacing it.
-        // Resume tracking the original bundle so the block watcher resolves
-        // the userOps against the mined transaction (inclusion, reverts,
-        // wallet release) instead of resending and reverting with AA25.
-        if (!bundleResult.success && bundleResult.reason === "already_mined") {
-            this.logger.info(
-                {
-                    oldTxHash,
-                    reason,
-                    userOps: getUserOpHashes(bundle.userOps)
-                },
-                "bundle mined during replacement, skipping replacement"
-            )
+        // The nonce of the bundle we tried to replace was consumed whilst
+        // replacing it.
+        if (!bundleResult.success && bundleResult.reason === "nonce_conflict") {
+            const [bundleStatus] = await this.bundleManager.getBundleStatuses([
+                submittedBundle
+            ])
 
-            this.bundleManager.trackBundle(submittedBundle)
-            this.startWatchingBlocks()
+            // One of the bundle's own transactions was mined - resolve the
+            // userOps against it now (inclusion, reverts, wallet release)
+            // instead of resending and reverting with AA25.
+            if (
+                bundleStatus.status === "included" ||
+                bundleStatus.status === "reverted"
+            ) {
+                this.logger.info(
+                    {
+                        oldTxHash,
+                        minedTxHash: bundleStatus.transactionHash,
+                        reason,
+                        userOps: getUserOpHashes(bundle.userOps)
+                    },
+                    "bundle mined during replacement, skipping replacement"
+                )
 
-            this.metrics.replacedTransactions
-                .labels({ reason, status: "already_mined" })
-                .inc()
+                this.metrics.replacedTransactions
+                    .labels({ reason, status: "already_mined" })
+                    .inc()
 
-            return
+                if (bundleStatus.status === "included") {
+                    await this.bundleManager.processIncludedBundle({
+                        submittedBundle,
+                        bundleReceipt: bundleStatus,
+                        blockReceivedTimestamp
+                    })
+                } else {
+                    await this.bundleManager.processRevertedBundle({
+                        submittedBundle,
+                        bundleReceipt: bundleStatus,
+                        blockReceivedTimestamp
+                    })
+                }
+
+                return
+            }
+
+            // The nonce was consumed by an unknown transaction (e.g. a
+            // cancel tx) - the userOps didn't land onchain, fall through to
+            // the failure handling below to resubmit them and free the
+            // wallet.
         }
 
         // Handle case where no bundle was sent.

--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -737,13 +737,17 @@ export class ExecutorManager {
 
         // Handle case where no bundle was sent.
         if (!bundleResult.success) {
-            const { rejectedUserOps, recoverableOps, reason } = bundleResult
+            const {
+                rejectedUserOps,
+                recoverableOps,
+                reason: failureReason
+            } = bundleResult
 
             // Recover any userOps that can be resubmitted.
             await this.mempool.resubmitUserOps({
                 userOps: recoverableOps,
                 entryPoint,
-                reason
+                reason: failureReason
             })
 
             // For rejected userOps, we need to check for frontruns
@@ -803,6 +807,7 @@ export class ExecutorManager {
                     {
                         oldTxHash,
                         reason,
+                        failureReason,
                         userOps: getUserOpHashes(rejectedUserOps)
                     },
                     "failed to replace bundle"

--- a/src/executor/utils.ts
+++ b/src/executor/utils.ts
@@ -26,12 +26,13 @@ import {
 import type { AltoConfig } from "../createConfig"
 import { getEip7702AuthAddress } from "../utils/eip7702"
 
-// Thrown during a replacement when the executor nonce was consumed by one of
-// the bundle's own previous transactions - the bundle already landed onchain
-// and resending it would revert with AA25.
-export class BundleAlreadyMinedError extends Error {
-    constructor(minedTxHash: Hex) {
-        super(`Bundle transaction ${minedTxHash} already mined`)
+// Thrown during a replacement when the executor nonce was consumed by another
+// transaction. The caller resolves whether it was one of the bundle's own
+// transactions (resending would revert with AA25) or an unknown transaction
+// (the userOps can be resubmitted).
+export class ReplacementNonceConflictError extends Error {
+    constructor() {
+        super("Replacement nonce consumed by another transaction")
     }
 }
 

--- a/src/executor/utils.ts
+++ b/src/executor/utils.ts
@@ -33,6 +33,7 @@ import { getEip7702AuthAddress } from "../utils/eip7702"
 export class ReplacementNonceConflictError extends Error {
     constructor() {
         super("Replacement nonce consumed by another transaction")
+        this.name = "ReplacementNonceConflictError"
     }
 }
 

--- a/src/executor/utils.ts
+++ b/src/executor/utils.ts
@@ -26,6 +26,15 @@ import {
 import type { AltoConfig } from "../createConfig"
 import { getEip7702AuthAddress } from "../utils/eip7702"
 
+// Thrown during a replacement when the executor nonce was consumed by one of
+// the bundle's own previous transactions - the bundle already landed onchain
+// and resending it would revert with AA25.
+export class BundleAlreadyMinedError extends Error {
+    constructor(minedTxHash: Hex) {
+        super(`Bundle transaction ${minedTxHash} already mined`)
+    }
+}
+
 export const getBundleGasLimit = async ({
     config,
     userOps,

--- a/src/types/mempool.ts
+++ b/src/types/mempool.ts
@@ -59,7 +59,7 @@ export type BundleResult =
               | "filterops_failed"
               | "insufficient_funds"
               | "generic_error"
-              | "already_mined"
+              | "nonce_conflict"
           rejectedUserOps: RejectedUserOp[]
           recoverableOps: UserOpInfo[]
       }

--- a/src/types/mempool.ts
+++ b/src/types/mempool.ts
@@ -55,7 +55,11 @@ export type BundleResult =
       }
     | {
           success: false
-          reason: "filterops_failed" | "insufficient_funds" | "generic_error"
+          reason:
+              | "filterops_failed"
+              | "insufficient_funds"
+              | "generic_error"
+              | "already_mined"
           rejectedUserOps: RejectedUserOp[]
           recoverableOps: UserOpInfo[]
       }


### PR DESCRIPTION
- Detect when a replacement transaction already consumed the nonce
- Preserve mined bundle tracking instead of resubmitting and reverting
- Add an explicit already_mined bundle result

Fixes #747