### PR TITLE
feat(metrics): scale inclusion buckets by block time

### DIFF
--- a/src/cli/handler.ts
+++ b/src/cli/handler.ts
@@ -272,6 +272,8 @@ export async function bundlerHandler(args_: IOptionsInput): Promise<void> {
     const registry = new Registry()
     const metrics = createMetrics(registry)
 
+    metrics.chainBlockTime.set(config.blockTime / 1000)
+
     await preFlightChecks(config)
 
     const senderManager = await getSenderManager({

--- a/src/executor/bundleManager.ts
+++ b/src/executor/bundleManager.ts
@@ -378,6 +378,9 @@ export class BundleManager {
 
             // Track metrics
             this.metrics.userOpInclusionDuration.observe(inclusionTimeMs / 1000)
+            this.metrics.userOpInclusionDurationBlocks.observe(
+                inclusionTimeMs / this.config.blockTime
+            )
             this.metrics.userOpsSubmissionAttempts.observe(submissionAttempts)
 
             // Update reputation

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -127,6 +127,17 @@ export function createMetrics(registry: Registry, register = true) {
         ]
     })
 
+    const userOpInclusionDurationBlocks = new Histogram({
+        name: "alto_user_operation_inclusion_duration_blocks",
+        help: "Number of blocks from first submission to inclusion on-chain",
+        labelNames: [] as const,
+        registers,
+        buckets: [
+            0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10, 12, 15, 20, 25, 30, 40, 50, 75,
+            100, 150, 200, 300
+        ]
+    })
+
     const verificationGasLimitEstimationTime = new Histogram({
         name: "alto_verification_gas_limit_estimation_time_seconds",
         help: "Total duration of verification gas limit estimation",
@@ -248,6 +259,7 @@ export function createMetrics(registry: Registry, register = true) {
         userOpsValidationSuccess,
         userOpsValidationFailure,
         userOpInclusionDuration,
+        userOpInclusionDurationBlocks,
         verificationGasLimitEstimationTime,
         verificationGasLimitEstimationCount,
         replacedTransactions,

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -127,8 +127,6 @@ export function createMetrics(registry: Registry, register = true) {
         ]
     })
 
-    // Set once at startup. Multiply block-based metrics by this gauge
-    // to convert them into seconds (e.g. in Grafana)
     const chainBlockTime = new Gauge({
         name: "alto_chain_block_time_seconds",
         help: "Configured block time of the chain in seconds",

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -127,6 +127,15 @@ export function createMetrics(registry: Registry, register = true) {
         ]
     })
 
+    // Set once at startup. Multiply block-based metrics by this gauge
+    // to convert them into seconds (e.g. in Grafana)
+    const chainBlockTime = new Gauge({
+        name: "alto_chain_block_time_seconds",
+        help: "Configured block time of the chain in seconds",
+        labelNames: [] as const,
+        registers
+    })
+
     const userOpInclusionDurationBlocks = new Histogram({
         name: "alto_user_operation_inclusion_duration_blocks",
         help: "Number of blocks from first submission to inclusion on-chain",
@@ -260,6 +269,7 @@ export function createMetrics(registry: Registry, register = true) {
         userOpsValidationFailure,
         userOpInclusionDuration,
         userOpInclusionDurationBlocks,
+        chainBlockTime,
         verificationGasLimitEstimationTime,
         verificationGasLimitEstimationCount,
         replacedTransactions,


### PR DESCRIPTION
- Pass configured chain block time into metrics creation

- Scale user operation inclusion histogram buckets by block duration
