### PR TITLE
fix(executor): sync retries with node nonce

### DIFF
--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -36,7 +36,8 @@ import {
     getAuthorizationListFromUserOps,
     getUserOpHashes,
     isFeeCapTooLowError,
-    isTransactionUnderpricedError
+    isTransactionUnderpricedError,
+    parseNonceFromError
 } from "./utils"
 
 type HandleOpsTxParams = {
@@ -376,14 +377,30 @@ export class Executor {
                 if (error instanceof TransactionExecutionError) {
                     const cause = error.cause
 
+                    // Prefer the nonce the node reported in its error;
+                    // otherwise step blindly toward it.
                     if (cause instanceof NonceTooLowError) {
-                        childLogger.warn("Nonce too low, retrying")
-                        request.nonce = request.nonce + 1
+                        const nodeNonce = parseNonceFromError(error)
+                        childLogger.warn(
+                            { txNonce: request.nonce, nodeNonce },
+                            "Nonce too low, retrying"
+                        )
+                        request.nonce =
+                            nodeNonce !== undefined && nodeNonce > request.nonce
+                                ? nodeNonce
+                                : request.nonce + 1
                     }
 
                     if (cause instanceof NonceTooHighError) {
-                        childLogger.warn("Nonce too high, retrying")
-                        request.nonce = request.nonce - 1
+                        const nodeNonce = parseNonceFromError(error)
+                        childLogger.warn(
+                            { txNonce: request.nonce, nodeNonce },
+                            "Nonce too high, retrying"
+                        )
+                        request.nonce =
+                            nodeNonce !== undefined && nodeNonce < request.nonce
+                                ? nodeNonce
+                                : request.nonce - 1
                     }
 
                     if (cause instanceof IntrinsicGasTooLowError) {

--- a/src/executor/utils.ts
+++ b/src/executor/utils.ts
@@ -89,6 +89,33 @@ export const isFeeCapTooLowError = (e: BaseError) => {
     return e.walk((err) => err instanceof FeeCapTooLowError) !== null
 }
 
+// Some nodes report the account's actual nonce in their "nonce too low" /
+// "nonce too high" rejection. Viem keeps the raw node message in `details`.
+//   nitro:        "nonce too low: address 0x.., tx: 389 state: 392"
+//   geth/op-geth: "nonce too low: next nonce 392, tx nonce 389"
+// Returns undefined when the message carries no nonce so callers can fall
+// back to a blind +1 / -1 adjustment.
+const NODE_NONCE_PATTERNS = [/\bstate:\s*(\d+)/i, /\bnext nonce\s*(\d+)/i]
+
+export const parseNonceFromError = (e: BaseError): number | undefined => {
+    const details = e.details
+    if (!details) {
+        return undefined
+    }
+
+    for (const pattern of NODE_NONCE_PATTERNS) {
+        const match = details.match(pattern)
+        if (match) {
+            const nonce = Number(match[1])
+            if (Number.isSafeInteger(nonce)) {
+                return nonce
+            }
+        }
+    }
+
+    return undefined
+}
+
 // V7 source: https://github.com/eth-infinitism/account-abstraction/blob/releases/v0.7/contracts/core/EntryPoint.sol
 // V6 source: https://github.com/eth-infinitism/account-abstraction/blob/fa61290d37d079e928d92d53a122efcc63822214/contracts/core/EntryPoint.sol#L236
 export function calculateAA95GasFloor({


### PR DESCRIPTION
- Parse node-reported nonce values from transaction errors

- Jump directly to the reported nonce when retrying
