### PR TITLE
fix(executor): drop per-attempt scaling from arbitrum gas bid

### DIFF
--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -128,20 +128,14 @@ export class Executor {
         // The bundler need to set a large enough gasBid to account for network baseFee fluctuations.
         // GasBid = min(maxFee, base + priority)
         if (chainType === "arbitrum") {
-            const scaledBaseFee = scaleBigIntByPercent(
+            const gasBid = scaleBigIntByPercent(
                 networkBaseFee,
-                100n + 20n * BigInt(bundle.submissionAttempts)
+                arbitrumBaseFeeMultiplier
             )
 
             return {
-                maxFeePerGas: scaleBigIntByPercent(
-                    scaledBaseFee,
-                    arbitrumBaseFeeMultiplier
-                ),
-                maxPriorityFeePerGas: scaleBigIntByPercent(
-                    scaledBaseFee,
-                    arbitrumBaseFeeMultiplier
-                )
+                maxFeePerGas: gasBid,
+                maxPriorityFeePerGas: gasBid
             }
         }
 


### PR DESCRIPTION
Arbitrum's sequencer is first come first served and the bid is
recomputed from a fresh base fee on every replacement, so scaling
by submission attempts bought no inclusion benefit while growing
the cap without a ceiling and inflating executor balance checks.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
